### PR TITLE
Expose trusted_proxies to parameters.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -17,7 +17,7 @@ framework:
         #assets_version: SomeVersionScheme
     default_locale:  "%default_locale%"
     trusted_hosts:   ~
-    trusted_proxies: ~
+    trusted_proxies: %trusted_proxies%
     session:
         # handler_id set to null will use default session handler from php.ini
         handler_id:  ~

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,4 +1,6 @@
 parameters:
+    trusted_proxies:   ~
+
     mailer_transport:  smtp
     mailer_host:       127.0.0.1
     mailer_user:       ~


### PR DESCRIPTION
Used trusted_proxies to make http -> https redirection work when the RA getting HTTP behind a reverse proxy. Is this the way to go?
