### PR TITLE
Render informative error screens in case of the below resp. statuses

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2015-02-12T12:29:19Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2015-02-23T14:09:03Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -22,6 +22,41 @@
         <jms:reference-file line="3">views/Exception/error404.html.twig</jms:reference-file>
         <source>ra.error.page_not_found.title</source>
         <target>Page not found</target>
+      </trans-unit>
+      <trans-unit id="47315f10d842cd2eebc6edd15f7fc5fa5bdeb631" resname="ra.error.saml_authn_failed.button.try_again">
+        <jms:reference-file line="10">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ra.error.saml_authn_failed.button.try_again</source>
+        <target>Retry sign-in</target>
+      </trans-unit>
+      <trans-unit id="175453c747d9009681e48b1fea3c1a5bb83077ad" resname="ra.error.saml_authn_failed.text.authn_failed">
+        <jms:reference-file line="8">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ra.error.saml_authn_failed.text.authn_failed</source>
+        <target>You were unable to sign in.</target>
+      </trans-unit>
+      <trans-unit id="91796128309d18718b9a06d39bd0b24a705e8c4e" resname="ra.error.saml_authn_failed.title">
+        <jms:reference-file line="3">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ra.error.saml_authn_failed.title</source>
+        <target>Sign in</target>
+      </trans-unit>
+      <trans-unit id="4c1a7f7aa6b9f7a2928e894933fac97b7d41198c" resname="ra.error.saml_no_authn_context.text.authn_failed">
+        <jms:reference-file line="8">Saml/Exception/noAuthnContext.html.twig</jms:reference-file>
+        <source>ra.error.saml_no_authn_context.text.authn_failed</source>
+        <target>You don't have the required security clearance to sign into the Registration Authority application.</target>
+      </trans-unit>
+      <trans-unit id="16cdeb502fd697b0179fb1a528fc59f216ba2184" resname="ra.error.saml_no_authn_context.title">
+        <jms:reference-file line="3">Saml/Exception/noAuthnContext.html.twig</jms:reference-file>
+        <source>ra.error.saml_no_authn_context.title</source>
+        <target>Security clearance too low</target>
+      </trans-unit>
+      <trans-unit id="d480fbb8440eb4218358f6d448b7033e5ddf201c" resname="ra.error.saml_precondition_not_met.text.precondition_not_met">
+        <jms:reference-file line="8">Saml/Exception/preconditionNotMet.html.twig</jms:reference-file>
+        <source>ra.error.saml_precondition_not_met.text.precondition_not_met</source>
+        <target>You don't meet all the requirements to be able to sign into the Registration Authority application.</target>
+      </trans-unit>
+      <trans-unit id="b286c74078cb8da3bc0126dc1d888d9f445468b9" resname="ra.error.saml_precondition_not_met.title">
+        <jms:reference-file line="3">Saml/Exception/preconditionNotMet.html.twig</jms:reference-file>
+        <source>ra.error.saml_precondition_not_met.title</source>
+        <target>Sign in</target>
       </trans-unit>
       <trans-unit id="40350a9cdf8f8964a6900f7dc524a91fa7b23df6" resname="ra.error.text.an_error_occurred">
         <jms:reference-file line="8">views/Exception/error.html.twig</jms:reference-file>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2015-02-12T12:29:18Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2015-02-23T14:09:01Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -22,6 +22,41 @@
         <jms:reference-file line="3">views/Exception/error404.html.twig</jms:reference-file>
         <source>ra.error.page_not_found.title</source>
         <target>Pagina niet gevonden</target>
+      </trans-unit>
+      <trans-unit id="47315f10d842cd2eebc6edd15f7fc5fa5bdeb631" resname="ra.error.saml_authn_failed.button.try_again">
+        <jms:reference-file line="10">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ra.error.saml_authn_failed.button.try_again</source>
+        <target>Opnieuw inloggen</target>
+      </trans-unit>
+      <trans-unit id="175453c747d9009681e48b1fea3c1a5bb83077ad" resname="ra.error.saml_authn_failed.text.authn_failed">
+        <jms:reference-file line="8">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ra.error.saml_authn_failed.text.authn_failed</source>
+        <target>U heeft niet in kunnen loggen.</target>
+      </trans-unit>
+      <trans-unit id="91796128309d18718b9a06d39bd0b24a705e8c4e" resname="ra.error.saml_authn_failed.title">
+        <jms:reference-file line="3">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ra.error.saml_authn_failed.title</source>
+        <target>Inloggen</target>
+      </trans-unit>
+      <trans-unit id="4c1a7f7aa6b9f7a2928e894933fac97b7d41198c" resname="ra.error.saml_no_authn_context.text.authn_failed">
+        <jms:reference-file line="8">Saml/Exception/noAuthnContext.html.twig</jms:reference-file>
+        <source>ra.error.saml_no_authn_context.text.authn_failed</source>
+        <target>U heeft niet de benodigde veiligheidsmachtiging om in de Registration Authority-applicatie in te loggen.</target>
+      </trans-unit>
+      <trans-unit id="16cdeb502fd697b0179fb1a528fc59f216ba2184" resname="ra.error.saml_no_authn_context.title">
+        <jms:reference-file line="3">Saml/Exception/noAuthnContext.html.twig</jms:reference-file>
+        <source>ra.error.saml_no_authn_context.title</source>
+        <target>Onvoldoende veiligheidsmachtiging</target>
+      </trans-unit>
+      <trans-unit id="d480fbb8440eb4218358f6d448b7033e5ddf201c" resname="ra.error.saml_precondition_not_met.text.precondition_not_met">
+        <jms:reference-file line="8">Saml/Exception/preconditionNotMet.html.twig</jms:reference-file>
+        <source>ra.error.saml_precondition_not_met.text.precondition_not_met</source>
+        <target>U voldoet niet aan alle voorwaarden om in te mogen loggen bij de Registration Authority-applicatie.</target>
+      </trans-unit>
+      <trans-unit id="b286c74078cb8da3bc0126dc1d888d9f445468b9" resname="ra.error.saml_precondition_not_met.title">
+        <jms:reference-file line="3">Saml/Exception/preconditionNotMet.html.twig</jms:reference-file>
+        <source>ra.error.saml_precondition_not_met.title</source>
+        <target>Inloggen</target>
       </trans-unit>
       <trans-unit id="40350a9cdf8f8964a6900f7dc524a91fa7b23df6" resname="ra.error.text.an_error_occurred">
         <jms:reference-file line="8">views/Exception/error.html.twig</jms:reference-file>

--- a/composer.lock
+++ b/composer.lock
@@ -1845,12 +1845,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SURFnet/Stepup-saml-bundle.git",
-                "reference": "9948f0e1eba25bf3fa5349fddfb88181d1056a44"
+                "reference": "f3be91f57c802ead44307ca94ace3774f1e8b090"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/9948f0e1eba25bf3fa5349fddfb88181d1056a44",
-                "reference": "9948f0e1eba25bf3fa5349fddfb88181d1056a44",
+                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/f3be91f57c802ead44307ca94ace3774f1e8b090",
+                "reference": "f3be91f57c802ead44307ca94ace3774f1e8b090",
                 "shasum": ""
             },
             "require": {
@@ -1883,7 +1883,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2015-02-11 12:41:51"
+            "time": "2015-02-23 13:01:51"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -111,6 +111,7 @@ services:
             - @ra.security.authentication.saml
             - @ra.security.authentication.session_handler
             - @logger
+            - @twig
 
     ra.security.authentication.saml:
         public: false

--- a/src/Resources/views/Saml/Exception/authnFailed.html.twig
+++ b/src/Resources/views/Saml/Exception/authnFailed.html.twig
@@ -1,0 +1,12 @@
+{% extends '::base.html.twig' %}
+
+{% block page_title %}{{ 'ra.error.saml_authn_failed.title'|trans }}{% endblock %}
+
+{% block content %}
+    <h2>{{ block('page_title') }}</h2>
+
+    <p>{{ 'ra.error.saml_authn_failed.text.authn_failed'|trans }}</p>
+    <a class="btn btn-primary" href="{{ path('ra_vetting_search') }}">
+        {{ 'ra.error.saml_authn_failed.button.try_again'|trans }}
+    </a>
+{% endblock %}

--- a/src/Resources/views/Saml/Exception/noAuthnContext.html.twig
+++ b/src/Resources/views/Saml/Exception/noAuthnContext.html.twig
@@ -1,0 +1,9 @@
+{% extends '::base.html.twig' %}
+
+{% block page_title %}{{ 'ra.error.saml_no_authn_context.title'|trans }}{% endblock %}
+
+{% block content %}
+    <h2>{{ block('page_title') }}</h2>
+
+    <p>{{ 'ra.error.saml_no_authn_context.text.authn_failed'|trans }}</p>
+{% endblock %}

--- a/src/Resources/views/Saml/Exception/preconditionNotMet.html.twig
+++ b/src/Resources/views/Saml/Exception/preconditionNotMet.html.twig
@@ -1,0 +1,9 @@
+{% extends '::base.html.twig' %}
+
+{% block page_title %}{{ 'ra.error.saml_precondition_not_met.title'|trans }}{% endblock %}
+
+{% block content %}
+    <h2>{{ block('page_title') }}</h2>
+
+    <p>{{ 'ra.error.saml_precondition_not_met.text.precondition_not_met'|trans }}</p>
+{% endblock %}

--- a/src/Security/Firewall/SamlListener.php
+++ b/src/Security/Firewall/SamlListener.php
@@ -112,6 +112,7 @@ class SamlListener implements ListenerInterface
         try {
             $assertion = $this->samlInteractionProvider->processSamlResponse($event->getRequest());
         } catch (PreconditionNotMetException $e) {
+            $this->logger->notice(sprintf('SAML response precondition not met: "%s"', $e->getMessage()));
             return $this->setPreconditionExceptionResponse($e, $event);
         } catch (Exception $e) {
             $this->logger->error(sprintf('Failed SAMLResponse Parsing: "%s"', $e->getMessage()));

--- a/src/Security/Firewall/SamlListener.php
+++ b/src/Security/Firewall/SamlListener.php
@@ -20,6 +20,9 @@ namespace Surfnet\StepupRa\RaBundle\Security\Firewall;
 
 use Exception;
 use Psr\Log\LoggerInterface;
+use SAML2_Response_Exception_PreconditionNotMetException as PreconditionNotMetException;
+use Surfnet\SamlBundle\Http\Exception\AuthnFailedSamlResponseException;
+use Surfnet\SamlBundle\Http\Exception\NoAuthnContextSamlResponseException;
 use Surfnet\SamlBundle\SAML2\Response\Assertion\InResponseTo;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\SamlInteractionProvider;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\SessionHandler;
@@ -31,6 +34,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
+use Twig_Environment as Twig;
 
 class SamlListener implements ListenerInterface
 {
@@ -59,18 +63,25 @@ class SamlListener implements ListenerInterface
      */
     private $sessionHandler;
 
+    /**
+     * @var \Twig_Environment
+     */
+    private $twig;
+
     public function __construct(
         SecurityContextInterface $securityContext,
         AuthenticationManagerInterface $authenticationManager,
         SamlInteractionProvider $samlInteractionProvider,
         SessionHandler $sessionHandler,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        Twig $twig
     ) {
         $this->securityContext          = $securityContext;
         $this->authenticationManager    = $authenticationManager;
         $this->samlInteractionProvider  = $samlInteractionProvider;
         $this->sessionHandler           = $sessionHandler;
         $this->logger                   = $logger;
+        $this->twig                     = $twig;
     }
 
     public function handle(GetResponseEvent $event)
@@ -100,6 +111,8 @@ class SamlListener implements ListenerInterface
         $expectedInResponseTo = $this->sessionHandler->getRequestId();
         try {
             $assertion = $this->samlInteractionProvider->processSamlResponse($event->getRequest());
+        } catch (PreconditionNotMetException $e) {
+            return $this->setPreconditionExceptionResponse($e, $event);
         } catch (Exception $e) {
             $this->logger->error(sprintf('Failed SAMLResponse Parsing: "%s"', $e->getMessage()));
             throw new AuthenticationException('Failed SAMLResponse parsing', 0, $e);
@@ -129,5 +142,21 @@ class SamlListener implements ListenerInterface
             $response->setStatusCode(Response::HTTP_FORBIDDEN);
             $event->setResponse($response);
         }
+    }
+
+    private function setPreconditionExceptionResponse(PreconditionNotMetException $exception, GetResponseEvent $event)
+    {
+        $template = null;
+
+        if ($exception instanceof AuthnFailedSamlResponseException) {
+            $template = 'SurfnetStepupRaRaBundle:Saml/Exception:authnFailed.html.twig';
+        } elseif ($exception instanceof NoAuthnContextSamlResponseException) {
+            $template = 'SurfnetStepupRaRaBundle:Saml/Exception:noAuthnContext.html.twig';
+        } else {
+            $template = 'SurfnetStepupRaRaBundle:Saml/Exception:preconditionNotMet.html.twig';
+        }
+
+        $html = $this->twig->render($template, ['exception' => $exception]);
+        $event->setResponse(new Response($html, Response::HTTP_UNAUTHORIZED));
     }
 }

--- a/src/Security/Firewall/SamlListener.php
+++ b/src/Security/Firewall/SamlListener.php
@@ -36,6 +36,9 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 use Twig_Environment as Twig;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class SamlListener implements ListenerInterface
 {
     /**


### PR DESCRIPTION
 - AuthnFailed - IdP failed to authenticate user
 - NoAuthnContext - LoA precondition not met
 - * - All other cases where preconditions weren't met

The reason the response is rendered and set from the SamlListener and
not from a kernel listener is the fact that the firewall errors out
when the listener doesn't set a token.

 - [x] Updated SAML bundle