### PR TITLE
Validate RA creation and amendment forms

### DIFF
--- a/app/Resources/translations/validators.en_GB.xliff
+++ b/app/Resources/translations/validators.en_GB.xliff
@@ -294,6 +294,22 @@
         <source>middleware_client.dto.vetted_second_factor.type.must_not_be_blank</source>
         <target>Vetted second factor's type may not be blank.</target>
       </trans-unit>
+      <trans-unit id="bcdfe3ce9a1c207e6cefccc3b20bdcbeb2370a62" resname="ra.accredit_candidate.contact_information.may_not_be_blank">
+        <source>ra.accredit_candidate.contact_information.may_not_be_blank</source>
+        <target>Contact information may not be blank</target>
+      </trans-unit>
+      <trans-unit id="aaa6ef853fef543fd67b8f5845de82e5cb214e98" resname="ra.accredit_candidate.location.may_not_be_blank">
+        <source>ra.accredit_candidate.location.may_not_be_blank</source>
+        <target>Location may not be blank</target>
+      </trans-unit>
+      <trans-unit id="75ad2fe7e5198417f56219c84b35bcefe6c21be1" resname="ra.amend_ra_information.contact_information">
+        <source>ra.amend_ra_information.contact_information</source>
+        <target>Contact information may not be blank</target>
+      </trans-unit>
+      <trans-unit id="eb93c9798d8f0004d45cd3adf417803ce93ac05b" resname="ra.amend_ra_information.location">
+        <source>ra.amend_ra_information.location</source>
+        <target>Location may not be blank</target>
+      </trans-unit>
       <trans-unit id="095af319676e1135c06bbe6bb8501816ca49fc33" resname="ra.form.extension.ra_role.must_be_valid_choice">
         <source>ra.form.extension.ra_role.must_be_valid_choice</source>
         <target>The selected role is not a valid choice</target>

--- a/app/Resources/translations/validators.nl_NL.xliff
+++ b/app/Resources/translations/validators.nl_NL.xliff
@@ -294,6 +294,22 @@
         <source>middleware_client.dto.vetted_second_factor.type.must_not_be_blank</source>
         <target>Vetted second factor's type may not be blank.</target>
       </trans-unit>
+      <trans-unit id="bcdfe3ce9a1c207e6cefccc3b20bdcbeb2370a62" resname="ra.accredit_candidate.contact_information.may_not_be_blank">
+        <source>ra.accredit_candidate.contact_information.may_not_be_blank</source>
+        <target>Contactinformatie moet gevuld zijn</target>
+      </trans-unit>
+      <trans-unit id="aaa6ef853fef543fd67b8f5845de82e5cb214e98" resname="ra.accredit_candidate.location.may_not_be_blank">
+        <source>ra.accredit_candidate.location.may_not_be_blank</source>
+        <target>Locatie moet gevuld zijn</target>
+      </trans-unit>
+      <trans-unit id="75ad2fe7e5198417f56219c84b35bcefe6c21be1" resname="ra.amend_ra_information.contact_information">
+        <source>ra.amend_ra_information.contact_information</source>
+        <target>Contactinformatie moet gevuld zijn</target>
+      </trans-unit>
+      <trans-unit id="eb93c9798d8f0004d45cd3adf417803ce93ac05b" resname="ra.amend_ra_information.location">
+        <source>ra.amend_ra_information.location</source>
+        <target>Locatie moet gevuld zijn</target>
+      </trans-unit>
       <trans-unit id="095af319676e1135c06bbe6bb8501816ca49fc33" resname="ra.form.extension.ra_role.must_be_valid_choice">
         <source>ra.form.extension.ra_role.must_be_valid_choice</source>
         <target>The selected role is not a valid choice</target>

--- a/src/Surfnet/StepupRa/RaBundle/Command/AccreditCandidateCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/AccreditCandidateCommand.php
@@ -33,11 +33,17 @@ class AccreditCandidateCommand
     public $institution;
 
     /**
+     * @Assert\NotBlank(message="ra.accredit_candidate.location.may_not_be_blank")
+     * @Assert\Type(type="string")
+     *
      * @var string
      */
     public $location;
 
     /**
+     * @Assert\NotBlank(message="ra.accredit_candidate.contact_information.may_not_be_blank")
+     * @Assert\Type(type="string")
+     *
      * @var string
      */
     public $contactInformation;

--- a/src/Surfnet/StepupRa/RaBundle/Command/AmendRegistrationAuthorityInformationCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/AmendRegistrationAuthorityInformationCommand.php
@@ -28,11 +28,17 @@ class AmendRegistrationAuthorityInformationCommand
     public $identityId;
 
     /**
+     * @Assert\NotBlank(message="ra.amend_ra_information.location")
+     * @Assert\Type(type="string")
+     *
      * @var string
      */
     public $location;
 
     /**
+     * @Assert\NotBlank(message="ra.amend_ra_information.contact_information")
+     * @Assert\Type(type="string")
+     *
      * @var string
      */
     public $contactInformation;

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/js/stepup-ra.js
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/js/stepup-ra.js
@@ -57,6 +57,11 @@
             var form = $('form[name="ra_management_create_ra"]'),
                 modal = $('#create_ra_confirmation_modal');
 
+            if (typeof form[0].checkValidity === 'function' && !form[0].checkValidity()) {
+                // Allow native validation behaviour.
+                return;
+            }
+
             event.preventDefault();
 
             modal
@@ -89,6 +94,11 @@
         $(document).on('click', 'form[name="ra_management_change_ra_role"] button.change-ra-role', function (event) {
             var form = $('form[name="ra_management_change_ra_role"]'),
                 modal = $('#change_ra_role_confirmation_modal');
+
+            if (typeof form[0].checkValidity === 'function' && !form[0].checkValidity()) {
+                // Allow native validation behaviour.
+                return;
+            }
 
             event.preventDefault();
 


### PR DESCRIPTION
This commit also falls back to native browser form validation behaviour when the form isn't valid at the time the submission modal is to be opened.