### PR TITLE
Use SF form for GSSF initiate action for CSRF protection

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/GssfController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/GssfController.php
@@ -57,7 +57,7 @@ final class GssfController extends SecondFactorController
             throw new NotFoundHttpException(sprintf('Vetting procedure "%s" not found', $procedureId));
         }
 
-        return ['procedureId' => $procedureId, 'provider' => $this->getProvider($provider)->getName()];
+        return $this->renderInitiateForm($procedureId, $this->getProvider($provider)->getName());
     }
 
     /**
@@ -186,9 +186,10 @@ final class GssfController extends SecondFactorController
             'GSSF ID registered in Self-Service does not match current GSSF ID'
         );
 
-        return $this->render(
-            'SurfnetStepupRaRaBundle:Vetting/Gssf:initiate.html.twig',
-            ['provider' => $provider->getName(), 'procedureId' => $result->getProcedureId(), 'gssfIdMismatch' => true]
+        return $this->renderInitiateForm(
+            $result->getProcedureId(),
+            $this->getProvider($provider)->getName(),
+            ['gssfIdMismatch' => true]
         );
     }
 
@@ -241,5 +242,23 @@ final class GssfController extends SecondFactorController
     private function getVettingService()
     {
         return $this->get('ra.service.vetting');
+    }
+
+    /**
+     * @param string $procedureId
+     * @param string $provider
+     * @param array  $parameters
+     * @return Response
+     */
+    private function renderInitiateForm($procedureId, $provider, array $parameters = [])
+    {
+        $form = $this->createForm('ra_initiate_gssf', null, ['procedureId' => $procedureId, 'provider' => $provider]);
+
+        $templateParameters = array_merge(
+            $parameters,
+            ['form' => $form->createView(), 'procedureId' => $procedureId, 'provider' => $provider]
+        );
+
+        return $this->render('SurfnetStepupRaRaBundle:Vetting/Gssf:initiate.html.twig', $templateParameters);
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/GssfController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/GssfController.php
@@ -188,7 +188,7 @@ final class GssfController extends SecondFactorController
 
         return $this->renderInitiateForm(
             $result->getProcedureId(),
-            $this->getProvider($provider)->getName(),
+            $provider->getName(),
             ['gssfIdMismatch' => true]
         );
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/InitiateGssfType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/InitiateGssfType.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Copyright 2015 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\RouterInterface;
+
+class InitiateGssfType extends AbstractType
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $action = $this->router->generate(
+            'ra_vetting_gssf_authenticate',
+            ['procedureId' => $options['procedureId'], 'provider' => $options['provider']]
+        );
+
+        $builder
+            ->add('submit', 'submit', [
+                'attr'  => ['class' => 'btn btn-primary'],
+                'label' => 'ra.vetting.gssf.initiate.' . $options['provider'] . '.button.initiate'
+            ])
+            ->setAction($action);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired(['procedureId', 'provider']);
+        $resolver->setAllowedTypes('procedureId', 'string');
+        $resolver->setAllowedTypes('provider', 'string');
+    }
+
+    public function getName()
+    {
+        return 'ra_initiate_gssf';
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -64,6 +64,12 @@ services:
         class: Surfnet\StepupRa\RaBundle\Form\Type\RetractRegistrationAuthorityType
         tags: [{ name: form.type, alias: ra_management_retract_registration_authority }]
 
+    ra.form.type.initiate_gssf:
+        class: Surfnet\StepupRa\RaBundle\Form\Type\InitiateGssfType
+        arguments:
+            - @router
+        tags: [{ name: form.type, alias: ra_initiate_gssf }]
+
     # Form Extensions
     ra.form.extension.institution_listing_choice_list:
         class: Surfnet\StepupRa\RaBundle\Form\Extension\InstitutionListingChoiceList

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/Vetting/Gssf/initiate.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/Vetting/Gssf/initiate.html.twig
@@ -15,13 +15,10 @@
 
     <hr>
 
-    <form action="{{ path('ra_vetting_gssf_authenticate', {'procedureId': procedureId, 'provider': provider}) }}" method="post">
-        {% if gssfIdMismatch is defined %}
-            <div class="alert alert-danger">{{ ('ra.vetting.gssf.initiate.' ~ provider ~ '.error.gssf_id_mismatch')|trans }}</div>
-        {% endif %}
-
-        <button type="submit" class="btn btn-primary">{{ ('ra.vetting.gssf.initiate.' ~ provider ~ '.button.initiate')|trans }}</button>
-    </form>
+    {% if gssfIdMismatch is defined %}
+        <div class="alert alert-danger">{{ ('ra.vetting.gssf.initiate.' ~ provider ~ '.error.gssf_id_mismatch')|trans }}</div>
+    {% endif %}
+    {{ form(form) }}
 
     <hr>
 


### PR DESCRIPTION
Addresses [Security Audit 5.6.1. Check for cross-site request forgery](https://www.pivotaltracker.com/story/show/104421476).

> Check-up resultaat
> 
> Het is nog steeds mogelijk om cross-site request forgery (CSRF) toe te passen binnen de scope van deze test. Dit checklist item is daarom gemarkeerd als ‘Failed’.
>
> Binnen de kwetsbare omgevingen wordt op een aantal plaatsen geen gebruik gemaakt van unieke formulier-tokens. De onderstaande tabel toont de functionaliteiten waar bescherming tegen cross- site request forgery niet is aangetroffen.
> 
> URL Methode
> 
> https://ra.test.surfconext.nl/vetting- POST procedure/d0e7e0ae-bf40-4e79-adc0- 62c84dfb225c/gssf/tiqr/authenticate
> 
> Functionaliteit
> 
> Initiëren Tiqr authenticatie
> 
> Een aanvaller kan deze kwetsbaarheden misbruiken om een Tiqr authenticatie te initiëren zonder dat de gebruiker hiervoor toestemming heeft gegeven.
>
> De oorspronkelijke kwetsbaarheidsscore en het oorspronkelijke advies blijven van kracht.

[1]: https://github.com/SURFnet/Stepup-SelfService/blob/742e8b4c1c76f446ef6c1eaddef6457438026acd/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/GssfController.php#L43