### PR TITLE
Send SMS challenge in registrant locale

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -87,6 +87,7 @@ services:
             - @ra.service.command
             - @ra.repository.vetting_procedure
             - @translator
+            - @surfnet_stepup_middleware_client.identity.service.identity
 
     ra.service.yubikey:
         public: false

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -87,7 +87,7 @@ services:
             - @ra.service.command
             - @ra.repository.vetting_procedure
             - @translator
-            - @surfnet_stepup_middleware_client.identity.service.identity
+            - @ra.service.identity
 
     ra.service.yubikey:
         public: false

--- a/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupRa\RaBundle\Service;
 
+use RuntimeException;
 use Surfnet\StepupBundle\Command\SendSmsChallengeCommand;
 use Surfnet\StepupBundle\Command\VerifyPossessionOfPhoneCommand;
 use Surfnet\StepupBundle\Service\SmsSecondFactor\OtpVerification;
@@ -192,7 +193,7 @@ class VettingService
      * @param SendSmsChallengeCommand $command
      * @return bool
      * @throws UnknownVettingProcedureException
-     * @throws DomainException
+     * @throws RuntimeException
      */
     public function sendSmsChallenge($procedureId, SendSmsChallengeCommand $command)
     {
@@ -205,7 +206,7 @@ class VettingService
         $identity = $this->identityService->findById($procedure->getSecondFactor()->identityId);
 
         if (!$identity) {
-            throw new DomainException("Second factor is coupled to an identity that doesn't exist");
+            throw new RuntimeException("Second factor is coupled to an identity that doesn't exist");
         }
 
         $command->phoneNumber = $phoneNumber;

--- a/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
@@ -206,7 +206,7 @@ class VettingService
         $identity = $this->identityService->get($procedure->getSecondFactor()->identityId);
 
         $command->phoneNumber = $phoneNumber;
-        $command->body        = $this->translator->trans('ra.vetting.sms.challenge_body', [], null, $identity->preferredLocale);
+        $command->body        = $this->translator->trans('ra.vetting.sms.challenge_body', [], 'messages', $identity->preferredLocale);
         $command->identity    = $procedure->getSecondFactor()->identityId;
         $command->institution = $procedure->getSecondFactor()->institution;
 

--- a/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
@@ -25,7 +25,6 @@ use Surfnet\StepupBundle\Service\SmsSecondFactorService;
 use Surfnet\StepupBundle\Value\PhoneNumber\InternationalPhoneNumber;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Command\VetSecondFactorCommand;
-use Surfnet\StepupMiddlewareClientBundle\Identity\Service\IdentityService;
 use Surfnet\StepupRa\RaBundle\Command\CreateU2fSignRequestCommand;
 use Surfnet\StepupRa\RaBundle\Command\StartVettingProcedureCommand;
 use Surfnet\StepupRa\RaBundle\Command\VerifyIdentityCommand;
@@ -86,7 +85,7 @@ class VettingService
     private $translator;
 
     /**
-     * @var \Surfnet\StepupMiddlewareClientBundle\Identity\Service\IdentityService
+     * @var \Surfnet\StepupRa\RaBundle\Service\IdentityService
      */
     private $identityService;
 
@@ -203,7 +202,11 @@ class VettingService
             $procedure->getSecondFactor()->secondFactorIdentifier
         );
 
-        $identity = $this->identityService->get($procedure->getSecondFactor()->identityId);
+        $identity = $this->identityService->findById($procedure->getSecondFactor()->identityId);
+
+        if (!$identity) {
+            throw new DomainException("Second factor is coupled to an identity that doesn't exist");
+        }
 
         $command->phoneNumber = $phoneNumber;
         $command->body        = $this->translator->trans('ra.vetting.sms.challenge_body', [], 'messages', $identity->preferredLocale);


### PR DESCRIPTION
Add IdentityService to VettingService and lookup SF identity, use it's locale for translation.

Completely untested but what do you think of injecting the IdentityService in the VettingService @rjkip ?