### PR TITLE
Add institution configuration options

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -43,7 +43,7 @@
                             <a href="{{ path('ra_management_manage') }}">{{ 'ra.menu.ra_management'|trans }}</a>
                         </li>
                     {% endif %}
-                    {% if institution_configuration_options.getInstitutionConfigurationOptions.useRaLocations %}
+                    {% if institutionConfigurationOptions.useRaLocations %}
                         <li role="presentation"{% if app.request.attributes.get('_route') starts with 'ra_locations' %} class="active"{% endif %}>
                             <a href="{{ path('ra_locations_manage') }}">{{ 'ra.menu.ra_locations'|trans }}</a>
                         </li>

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -43,7 +43,7 @@
                             <a href="{{ path('ra_management_manage') }}">{{ 'ra.menu.ra_management'|trans }}</a>
                         </li>
                     {% endif %}
-                    {% if showsRaLocations %}
+                    {% if institution_configuration_options.getInstitutionConfigurationOptions.useRaLocations %}
                         <li role="presentation"{% if app.request.attributes.get('_route') starts with 'ra_locations' %} class="active"{% endif %}>
                             <a href="{{ path('ra_locations_manage') }}">{{ 'ra.menu.ra_locations'|trans }}</a>
                         </li>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -37,7 +37,7 @@ twig:
     exception_controller:  SurfnetStepupBundle:Exception:show
     globals:
         footer_link_url: %footer_link_url%
-        institution_configuration_options: "@ra.twig.institution_configuration_options"
+        institutionConfigurationOptions: "@ra.twig.institution_configuration_options"
 
 # Assetic Configuration
 assetic:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -37,6 +37,7 @@ twig:
     exception_controller:  SurfnetStepupBundle:Exception:show
     globals:
         footer_link_url: %footer_link_url%
+        institution_configuration_options: "@ra.twig.institution_configuration_options"
 
 # Assetic Configuration
 assetic:

--- a/build-pre-commit.xml
+++ b/build-pre-commit.xml
@@ -123,7 +123,13 @@
         <echo message="OK"/>
     </target>
 
-    <target name="phpmd" depends="get-changeset.php-commasep.notests" if="changeset.php.notempty">
+    <target name="get-changeset.without-tests" depends="get-changeset.php-commasep.notests" if="changeset.php.notempty">
+        <condition property="changeset.php.absolute.notests.notempty">
+            <isset property="changeset.php.absolute.notests"/>
+        </condition>
+    </target>
+
+    <target name="phpmd" depends="get-changeset.without-tests" if="changeset.php.absolute.notests.notempty">
         <exec executable="${test-tree-location}/vendor/bin/phpmd" failonerror="true">
             <arg line="${changeset.php.absolute.notests} text ${test-tree-location}/phpmd-pre-commit.xml" />
         </exec>

--- a/build-pre-commit.xml
+++ b/build-pre-commit.xml
@@ -148,7 +148,7 @@
     </target>
 
     <target name="php-license" depends="get-changeset.php-spacesep" if="changeset.php.notempty">
-        <exec executable="/bin/grep" failonerror="false" outputproperty="php-license.grep.output">
+        <exec executable="/bin/grep" failonerror="true" outputproperty="php-license.grep.output">
             <arg value="-L"/>
             <arg value="LICENSE-2.0"/>
             <arg line="${changeset.php.absolute.spacesep}"/>

--- a/src/Surfnet/StepupRa/RaBundle/EventListener/InconsistentStateListener.php
+++ b/src/Surfnet/StepupRa/RaBundle/EventListener/InconsistentStateListener.php
@@ -38,11 +38,13 @@ class InconsistentStateListener
     {
         $exception = $event->getException();
 
-        if ($exception instanceof InconsistentStateException) {
-            $this->logger->critical(
-                sprintf('An inconsistent state has been reached: "%s"', $exception->getMessage()),
-                ['exception' => $exception]
-            );
+        if (!$exception instanceof InconsistentStateException) {
+            return;
         }
+
+        $this->logger->critical(
+            sprintf('An inconsistent state has been reached: "%s"', $exception->getMessage()),
+            ['exception' => $exception]
+        );
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/EventListener/InconsistentStateListener.php
+++ b/src/Surfnet/StepupRa/RaBundle/EventListener/InconsistentStateListener.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\StepupRa\RaBundle\Exception\InconsistentStateException;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+
+class InconsistentStateListener
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $exception = $event->getException();
+
+        if ($exception instanceof InconsistentStateException) {
+            $this->logger->critical(
+                sprintf('An inconsistent state has been reached: "%s"', $exception->getMessage()),
+                ['exception' => $exception]
+            );
+        }
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Exception/InconsistentStateException.php
+++ b/src/Surfnet/StepupRa/RaBundle/Exception/InconsistentStateException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Exception;
+
+class InconsistentStateException extends RuntimeException
+{
+}

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -271,6 +271,13 @@ services:
         arguments: ['@twig', '@ra.service.institution_with_personal_ra_locations', '@security.context']
         tags: [{ name: kernel.event_subscriber }]
 
+    ra.exception_listener.inconsistent_state:
+        class: Surfnet\StepupRa\RaBundle\EventListener\InconsistentStateListener
+        arguments:
+            - "@logger"
+        tags:
+            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
+
     # Twig
     ra.twig.institution_configuration_options:
         class: Surfnet\StepupRa\RaBundle\Twig\InstitutionConfigurationOptions

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -169,6 +169,11 @@ services:
             - @security.token_storage
             - @logger
 
+    ra.service.institution_configuration_options:
+        class: Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsService
+        arguments:
+            - "@surfnet_stepup_middleware_client.configuration.service.institution_configuration_options"
+
     ra.service.institution_with_personal_ra_locations:
         class: Surfnet\StepupRa\RaBundle\Service\InstitutionWithPersonalRaLocationsService
         arguments:

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -225,6 +225,7 @@ services:
         arguments:
             - @ra.service.identity
             - @surfnet_saml.saml.attribute_dictionary
+            - @ra.service.institution_configuration_options
 
     ra.security.authentication.listener:
         class: Surfnet\StepupRa\RaBundle\Security\Firewall\SamlListener
@@ -269,3 +270,9 @@ services:
         class: Surfnet\StepupRa\RaBundle\EventListener\ShowsRaLocationsListener
         arguments: ['@twig', '@ra.service.institution_with_personal_ra_locations', '@security.context']
         tags: [{ name: kernel.event_subscriber }]
+
+    # Twig
+    ra.twig.institution_configuration_options:
+        class: Surfnet\StepupRa\RaBundle\Twig\InstitutionConfigurationOptions
+        arguments:
+            - "@security.token_storage"

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Security\Authentication\Provider;
 
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use Surfnet\StepupRa\RaBundle\Exception\InconsistentStateException;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Service\IdentityService;
 use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsService;
@@ -108,6 +109,15 @@ class SamlProvider implements AuthenticationProviderInterface
 
         $institutionConfigurationOptions = $this->institutionConfigurationOptionsService
             ->getInstitutionConfigurationOptionsFor($identity->institution);
+
+        if ($institutionConfigurationOptions === null) {
+            throw new InconsistentStateException(
+                sprintf(
+                    'No institution configuration options can be found for institution "%s"',
+                    $identity->institution
+                )
+            );
+        }
 
         // set the token
         $authenticatedToken = new SamlToken($token->getLoa(), $roles, $institutionConfigurationOptions);

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
@@ -113,8 +113,10 @@ class SamlProvider implements AuthenticationProviderInterface
         if ($institutionConfigurationOptions === null) {
             throw new InconsistentStateException(
                 sprintf(
-                    'No institution configuration options can be found for institution "%s"',
-                    $identity->institution
+                    'InstitutionConfigurationOptions for institution "%s" '
+                    . 'must exist but cannot be found after authenticating Identity "%s"',
+                    $identity->institution,
+                    $identity->id
                 )
             );
         }

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
@@ -61,7 +61,7 @@ class SamlProvider implements AuthenticationProviderInterface
     {
         $translatedAssertion = $this->attributeDictionary->translate($token->assertion);
 
-        $nameId      = $translatedAssertion->getNameID();
+        $nameId       = $translatedAssertion->getNameID();
         $institutions = $translatedAssertion->getAttributeValue('schacHomeOrganization');
 
         if (empty($institutions)) {

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
@@ -18,10 +18,10 @@
 
 namespace Surfnet\StepupRa\RaBundle\Security\Authentication\Provider;
 
-
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Service\IdentityService;
+use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsService;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
@@ -38,12 +38,19 @@ class SamlProvider implements AuthenticationProviderInterface
      */
     private $attributeDictionary;
 
+    /**
+     * @var InstitutionConfigurationOptionsService
+     */
+    private $institutionConfigurationOptionsService;
+
     public function __construct(
         IdentityService $identityService,
-        AttributeDictionary $attributeDictionary
+        AttributeDictionary $attributeDictionary,
+        InstitutionConfigurationOptionsService $institutionConfigurationOptionsService
     ) {
-        $this->identityService = $identityService;
-        $this->attributeDictionary = $attributeDictionary;
+        $this->identityService                        = $identityService;
+        $this->attributeDictionary                    = $attributeDictionary;
+        $this->institutionConfigurationOptionsService = $institutionConfigurationOptionsService;
     }
 
     /**
@@ -99,8 +106,11 @@ class SamlProvider implements AuthenticationProviderInterface
             $roles[] = 'ROLE_RA';
         }
 
+        $institutionConfigurationOptions = $this->institutionConfigurationOptionsService
+            ->getInstitutionConfigurationOptionsFor($identity->institution);
+
         // set the token
-        $authenticatedToken = new SamlToken($token->getLoa(), $roles);
+        $authenticatedToken = new SamlToken($token->getLoa(), $roles, $institutionConfigurationOptions);
         $authenticatedToken->setUser($identity);
 
         return $authenticatedToken;

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Security\Authentication\Token;
 
 use Surfnet\StepupBundle\Value\Loa;
+use Surfnet\StepupMiddlewareClientBundle\Configuration\Dto\InstitutionConfigurationOptions;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 
 class SamlToken extends AbstractToken
@@ -33,12 +34,29 @@ class SamlToken extends AbstractToken
      */
     private $loa;
 
-    public function __construct(Loa $loa, array $roles = array())
-    {
+    /**
+     * @var InstitutionConfigurationOptions
+     */
+    private $institutionConfigurationOptions;
+
+    public function __construct(
+        Loa $loa,
+        array $roles = [],
+        InstitutionConfigurationOptions $institutionConfigurationOptions = null
+    ) {
         parent::__construct($roles);
 
         $this->loa = $loa;
+        $this->institutionConfigurationOptions = $institutionConfigurationOptions;
         $this->setAuthenticated(count($roles));
+    }
+
+    /**
+     * @return InstitutionConfigurationOptions
+     */
+    public function getInstitutionConfigurationOptions()
+    {
+        return $this->institutionConfigurationOptions;
     }
 
     /**
@@ -61,12 +79,12 @@ class SamlToken extends AbstractToken
 
     public function serialize()
     {
-        return serialize([parent::serialize(), $this->loa,]);
+        return serialize([parent::serialize(), $this->loa, $this->institutionConfigurationOptions]);
     }
 
     public function unserialize($serialized)
     {
-        list($parent, $this->loa) = unserialize($serialized);
+        list($parent, $this->loa, $this->institutionConfigurationOptions) = unserialize($serialized);
 
         parent::unserialize($parent);
     }

--- a/src/Surfnet/StepupRa/RaBundle/Service/InstitutionConfigurationOptionsService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/InstitutionConfigurationOptionsService.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Service;
+
+use Surfnet\StepupMiddlewareClientBundle\Configuration\Service\InstitutionConfigurationOptionsService as ApiInstitutionConfigurationOptionsService;
+
+final class InstitutionConfigurationOptionsService
+{
+    /**
+     * @var ApiInstitutionConfigurationOptionsService
+     */
+    private $apiInstitutionConfigurationOptionsService;
+
+    public function __construct(ApiInstitutionConfigurationOptionsService $apiService)
+    {
+        $this->apiInstitutionConfigurationOptionsService = $apiService;
+    }
+
+    public function getInstitutionConfigurationOptionsFor($institution)
+    {
+        return $this->apiInstitutionConfigurationOptionsService->getInstitutionConfigurationOptionsFor($institution);
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authentication/Token/SamlTokenTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authentication/Token/SamlTokenTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Tests\Security\Authentication\Token;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\StepupBundle\Value\Loa;
+use Surfnet\StepupMiddlewareClientBundle\Configuration\Dto\InstitutionConfigurationOptions;
+use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
+
+class SamlTokenTest extends TestCase
+{
+    /**
+     * @test
+     * @group saml
+     * @group serialization
+     */
+    public function saml_token_is_correctly_serialized_and_unserialized()
+    {
+        $institutionConfigurationOptions = new InstitutionConfigurationOptions();
+        $institutionConfigurationOptions->useRaLocations = true;
+        $institutionConfigurationOptions->showRaaContactInformation = false;
+
+        $samlToken = new SamlToken(
+            new Loa(Loa::LOA_1, 'http://some.url.tld/authentication/loa1'),
+            ['ROLE_RAA'],
+            $institutionConfigurationOptions
+        );
+
+        $serialized = $samlToken->serialize();
+
+        $deserialized = new SamlToken(new Loa(Loa::LOA_2, 'http://some.url.tld/authentication/loa2'));
+        $deserialized->unserialize($serialized);
+
+        $this->assertEquals($samlToken, $deserialized);
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Twig/InstitutionConfigurationOptions.php
+++ b/src/Surfnet/StepupRa/RaBundle/Twig/InstitutionConfigurationOptions.php
@@ -23,21 +23,30 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 final class InstitutionConfigurationOptions
 {
-    /**
-     * @var TokenStorageInterface
-     */
-    private $tokenStorage;
-
     public function __construct(TokenStorageInterface $tokenStorage)
     {
         $this->tokenStorage = $tokenStorage;
     }
 
-    public function getInstitutionConfigurationOptions()
+    /**
+     * @return boolean
+     */
+    public function useRaLocations()
     {
         /** @var SamlToken $token */
         $token = $this->tokenStorage->getToken();
 
-        return $token->getInstitutionConfigurationOptions();
+        return $token->getInstitutionConfigurationOptions()->useRaLocations;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function showRaaContactInformation()
+    {
+        /** @var SamlToken $token */
+        $token = $this->tokenStorage->getToken();
+
+        return $token->getInstitutionConfigurationOptions()->showRaaContactInformation;
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Twig/InstitutionConfigurationOptions.php
+++ b/src/Surfnet/StepupRa/RaBundle/Twig/InstitutionConfigurationOptions.php
@@ -23,6 +23,11 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 final class InstitutionConfigurationOptions
 {
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
     public function __construct(TokenStorageInterface $tokenStorage)
     {
         $this->tokenStorage = $tokenStorage;

--- a/src/Surfnet/StepupRa/RaBundle/Twig/InstitutionConfigurationOptions.php
+++ b/src/Surfnet/StepupRa/RaBundle/Twig/InstitutionConfigurationOptions.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Twig;
+
+use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+final class InstitutionConfigurationOptions
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function getInstitutionConfigurationOptions()
+    {
+        /** @var SamlToken $token */
+        $token = $this->tokenStorage->getToken();
+
+        return $token->getInstitutionConfigurationOptions();
+    }
+}


### PR DESCRIPTION
This PR adds InstitutionConfigurationOptions to the `SamlToken`. The options are set whenever a user has been authenticated and are exposed to Twig via global parameters.

This can only be merged when a stable MiddlewareClientBundle release is required through composer, offering the InstitutionConfigurationOptions API.

_Note: commit history has been rebased to make more sense, yet Github show it chronologically_