### PR TITLE
Fix RA locations appearance and token data

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -30,7 +30,7 @@
             {% block menu %}
             {% if app.user %}
             <div class="row-fluid">
-                <div class="col-sm-6">
+                <div class="col-sm-8">
                     <ul class="nav nav-pills">
                         <li role="presentation"{% if app.request.attributes.get('_route') starts with 'ra_vetting' %} class="active"{% endif %}>
                             <a href="{{ path('ra_vetting_search') }}">{{ 'ra.menu.registration'|trans }}</a>
@@ -50,7 +50,7 @@
                     {% endif %}
                     </ul>
                 </div>
-                <div class="col-sm-6">
+                <div class="col-sm-4">
                     <form name="logout" method="post" action="{{ logout_url('saml_based') }}" class="pull-right">
                         <button type="submit" class="btn btn-link"><i class="fa fa-sign-out"></i> {{ 'button.logout'|trans }}</button>
                     </form>

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
@@ -119,8 +119,9 @@ class SamlProvider implements AuthenticationProviderInterface
         }
 
         // set the token
-        $authenticatedToken = new SamlToken($token->getLoa(), $roles, $institutionConfigurationOptions);
+        $authenticatedToken = new SamlToken($token->getLoa(), $roles);
         $authenticatedToken->setUser($identity);
+        $authenticatedToken->setInstitutionConfigurationOptions($institutionConfigurationOptions);
 
         return $authenticatedToken;
     }

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
@@ -39,16 +39,17 @@ class SamlToken extends AbstractToken
      */
     private $institutionConfigurationOptions;
 
-    public function __construct(
-        Loa $loa,
-        array $roles = [],
-        InstitutionConfigurationOptions $institutionConfigurationOptions = null
-    ) {
+    public function __construct(Loa $loa, array $roles = [])
+    {
         parent::__construct($roles);
 
         $this->loa = $loa;
-        $this->institutionConfigurationOptions = $institutionConfigurationOptions;
         $this->setAuthenticated(count($roles));
+    }
+
+    public function setInstitutionConfigurationOptions(InstitutionConfigurationOptions $institutionConfigurationOptions)
+    {
+        $this->institutionConfigurationOptions = $institutionConfigurationOptions;
     }
 
     /**


### PR DESCRIPTION
See [comment](https://www.pivotaltracker.com/story/show/116602125/comments/146521669).

This fixes the issue that, when changing institutions as SRAA, the institution configuration options are used for the SRAAs institution instead of the selected institution.

The left navigation has gotten more room for its components, yet the navigation UI could use some work to allow for expansion of the left or right menu.