### PR TITLE
Convert string to integer when paginating

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -93,7 +93,7 @@ class RaManagementController extends Controller
 
         $command                 = new SearchRaCandidatesCommand();
         $command->institution    = $institution;
-        $command->pageNumber     = $request->get('p', 1);
+        $command->pageNumber     = (integer) $request->get('p', 1);
         $command->orderBy        = $request->get('orderBy');
         $command->orderDirection = $request->get('orderDirection');
 

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -92,12 +92,9 @@ class RaManagementController extends Controller
 
         $logger->notice(sprintf('Searching for RaCandidates within institution "%s"', $institution));
 
-        $pageNumber = $request->get('p', 1);
-        Assertion::digit($pageNumber, 'Expected page number to be an integer, got "%s"');
-
         $command                 = new SearchRaCandidatesCommand();
         $command->institution    = $institution;
-        $command->pageNumber     = $pageNumber;
+        $command->pageNumber     = (int) $request->get('p', 1);
         $command->orderBy        = $request->get('orderBy');
         $command->orderDirection = $request->get('orderDirection');
 

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\StepupRa\RaBundle\Controller;
 
-use Assert\Assertion;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\RaListingSearchQuery;
 use Surfnet\StepupRa\RaBundle\Command\AccreditCandidateCommand;
 use Surfnet\StepupRa\RaBundle\Command\AmendRegistrationAuthorityInformationCommand;

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupRa\RaBundle\Controller;
 
+use Assert\Assertion;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\RaListingSearchQuery;
 use Surfnet\StepupRa\RaBundle\Command\AccreditCandidateCommand;
 use Surfnet\StepupRa\RaBundle\Command\AmendRegistrationAuthorityInformationCommand;
@@ -91,9 +92,12 @@ class RaManagementController extends Controller
 
         $logger->notice(sprintf('Searching for RaCandidates within institution "%s"', $institution));
 
+        $pageNumber = $request->get('p', 1);
+        Assertion::digit($pageNumber, 'Expected page number to be an integer, got "%s"');
+
         $command                 = new SearchRaCandidatesCommand();
         $command->institution    = $institution;
-        $command->pageNumber     = (integer) $request->get('p', 1);
+        $command->pageNumber     = $pageNumber;
         $command->orderBy        = $request->get('orderBy');
         $command->orderDirection = $request->get('orderDirection');
 


### PR DESCRIPTION
[130522531](https://www.pivotaltracker.com/story/show/130522531)

The issue relates to the page number (the `p` in the query string) being extracted as a string, while, in the `SearchRaCandidatesCommand`, the page number is [expected to be an integer](https://github.com/SURFnet/Stepup-RA/blob/45be0aebb1440d780cc01e42176bebe3aca896e8/src/Surfnet/StepupRa/RaBundle/Command/SearchRaCandidatesCommand.php#L60-L66).