### PR TITLE
Implement locale cookie listener from StepupBundle into RA

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/EventListener/LocaleListener.php
+++ b/src/Surfnet/StepupRa/RaBundle/EventListener/LocaleListener.php
@@ -18,48 +18,36 @@
 
 namespace Surfnet\StepupRa\RaBundle\EventListener;
 
-use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
+use Surfnet\StepupBundle\Service\LocaleProviderService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 final class LocaleListener implements EventSubscriberInterface
 {
     /**
-     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
+     * @var LocaleProviderService
      */
-    private $tokenStorage;
+    private $localeProviderService;
 
     /**
      * @var TranslatorInterface
      */
     private $translator;
 
-    public function __construct(TokenStorageInterface $tokenStorage, TranslatorInterface $translator)
+    public function __construct(LocaleProviderService $localeProviderService, TranslatorInterface $translator)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->localeProviderService = $localeProviderService;
         $this->translator = $translator;
     }
 
     public function setRequestLocale(GetResponseEvent $event)
     {
-        $token = $this->tokenStorage->getToken();
-
-        if (!$token) {
-            return;
-        }
-
-        /** @var Identity $identity */
-        $identity = $token->getUser();
-
-        if (!$identity instanceof Identity) {
-            return;
-        }
+        $preferredLocale = $this->localeProviderService->determinePreferredLocale();
 
         $request = $event->getRequest();
-        $request->setLocale($identity->preferredLocale);
+        $request->setLocale($preferredLocale);
 
         // As per \Symfony\Component\HttpKernel\EventListener\TranslatorListener::setLocale()
         try {

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -228,7 +228,7 @@ services:
     # Listeners
     ra.event_listener.locale:
         class: Surfnet\StepupRa\RaBundle\EventListener\LocaleListener
-        arguments: [ "@security.token_storage", "@translator" ]
+        arguments: [ "@ra.service.locale_provider", "@translator" ]
         tags: [{ name: kernel.event_subscriber }]
 
     ra.event_listener.locale_cookie:

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -231,6 +231,15 @@ services:
         arguments: [ "@security.token_storage", "@translator" ]
         tags: [{ name: kernel.event_subscriber }]
 
+    ra.event_listener.locale_cookie:
+        class: Surfnet\StepupBundle\EventListener\LocaleCookieListener
+        arguments:
+            - "@surfnet_stepup.locale_cookie_helper"
+            - "@ra.service.locale_provider"
+            - "@logger"
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: 6 }
+
     ra.exception_listener.inconsistent_state:
         class: Surfnet\StepupRa\RaBundle\EventListener\InconsistentStateListener
         arguments:

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -174,6 +174,11 @@ services:
         arguments:
             - "@surfnet_stepup_middleware_client.configuration.service.institution_configuration_options"
 
+    ra.service.locale_provider:
+        class: Surfnet\StepupRa\RaBundle\Service\LocaleProviderService
+        arguments:
+            - "@security.token_storage"
+
     ra.service.ra_candidate:
         class: Surfnet\StepupRa\RaBundle\Service\RaCandidateService
         arguments:

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -228,7 +228,7 @@ services:
     # Listeners
     ra.event_listener.locale:
         class: Surfnet\StepupRa\RaBundle\EventListener\LocaleListener
-        arguments: [ "@ra.service.locale_provider", "@translator" ]
+        arguments: [ "@security.token_storage", "@translator" ]
         tags: [{ name: kernel.event_subscriber }]
 
     ra.event_listener.locale_cookie:

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Handler/ExplicitSessionTimeoutHandler.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Handler/ExplicitSessionTimeoutHandler.php
@@ -28,6 +28,9 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Http\Logout\CookieClearingLogoutHandler;
 use Symfony\Component\Security\Http\Logout\SessionLogoutHandler;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class ExplicitSessionTimeoutHandler implements AuthenticationHandler
 {
     /**

--- a/src/Surfnet/StepupRa/RaBundle/Service/LocaleProviderService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/LocaleProviderService.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Service;
+
+use Surfnet\StepupBundle\Service\LocaleProviderService as StepupLocaleProviderService;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+final class LocaleProviderService implements StepupLocaleProviderService
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function determinePreferredLocale()
+    {
+        $token = $this->tokenStorage->getToken();
+
+        if (!$token) {
+            return;
+        }
+
+        /** @var Identity $identity */
+        $identity = $token->getUser();
+
+        if (!$identity instanceof Identity) {
+            return;
+        }
+
+        return $identity->preferredLocale;
+    }
+}


### PR DESCRIPTION
[113611545](https://www.pivotaltracker.com/story/show/113611545)

Gateway determines it locale solely based on the identity's SecondFactor. The displayed language is currently determined by the locale of SelfService and RA, which are stored in their sessions. MW/GW don't know about these locales upon entry. Furthermore, GW does not store any state about the identity. This is why the LocaleCookieListener will be implemented in RA and in SelfService.

This implements the locale cookie listener from the StepupBundle into RA.

For its SelfService counter-part, see: [Stepup-SelfService #111](https://github.com/SURFnet/Stepup-SelfService/pull/111).