### PR TITLE
Remove '(optional)' from forms

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -89,6 +89,7 @@ surfnet_stepup_ra_ra:
 
 mopa_bootstrap:
     form:
+        render_optional_text: false
         show_legend: false
         templating: SurfnetStepupRaRaBundle:Form:fields.html.twig
     icons:


### PR DESCRIPTION
[133251949](https://www.pivotaltracker.com/story/show/133251949)

For forms to come, if there are texts where "(optional)" is required, that can be done in the builder for the form when necessary.

![screen shot 2016-11-01 at 14 12 56](https://cloud.githubusercontent.com/assets/3816591/19891333/e88a4c6e-a03f-11e6-852c-171b09ddd3f7.png)
