### PR TITLE
Restrict document number input to a maximum of six characters

### DIFF
--- a/app/Resources/translations/validators.en_GB.xliff
+++ b/app/Resources/translations/validators.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-08-12T13:45:09Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2016-11-03T10:43:41Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -8,11 +8,11 @@
     <body>
       <trans-unit id="e921db3beb8170142aa4dcd8c364595343b6fc64" resname="middleware_client.dto.configuration.show_raa_contact_information.must_be_boolean">
         <source>middleware_client.dto.configuration.show_raa_contact_information.must_be_boolean</source>
-        <target state="new">middleware_client.dto.configuration.show_raa_contact_information.must_be_boolean</target>
+        <target>Show RAA Contact Information option must be boolean.</target>
       </trans-unit>
       <trans-unit id="53ef4f54259698cee5e0aaba2d7f20417cd8e9fb" resname="middleware_client.dto.configuration.use_ra_locations.must_be_boolean">
         <source>middleware_client.dto.configuration.use_ra_locations.must_be_boolean</source>
-        <target state="new">middleware_client.dto.configuration.use_ra_locations.must_be_boolean</target>
+        <target>Use RA locations option must be boolean.</target>
       </trans-unit>
       <trans-unit id="f033a6177f4f371fbc302f07a6b8c67ec8b46549" resname="middleware_client.dto.identity.common_name.must_be_string">
         <source>middleware_client.dto.identity.common_name.must_be_string</source>

--- a/app/Resources/translations/validators.en_GB.xliff
+++ b/app/Resources/translations/validators.en_GB.xliff
@@ -430,6 +430,14 @@
         <source>ra.verify_identity_command.document_number.may_not_be_empty</source>
         <target>Enter the last 6 characters of document number</target>
       </trans-unit>
+      <trans-unit id="94785a2a9091f214657771372fcb4a61d47948bd" resname="ra.verify_identity_command.document_number.must_be_higher_than_minimum">
+        <source>ra.verify_identity_command.document_number.must_be_higher_than_minimum</source>
+        <target>Document number must consist of at least {{ limit }} character.|Document number must consist of at least {{ limit }} characters.</target>
+      </trans-unit>
+      <trans-unit id="5b10a05ddf6d1e4e7073de3dbbde2c7a095870ff" resname="ra.verify_identity_command.document_number.must_be_lower_than_maximum">
+        <source>ra.verify_identity_command.document_number.must_be_lower_than_maximum</source>
+        <target>Document number must consist of at most {{ limit }} character.|Document number must consist of at most {{ limit }} characters.</target>
+      </trans-unit>
       <trans-unit id="6a7721edc1618980a3d081cf8df1585ec10018ec" resname="ra.verify_identity_command.document_number.must_be_string">
         <source>ra.verify_identity_command.document_number.must_be_string</source>
         <target>Enter the last 6 characters of document number</target>

--- a/app/Resources/translations/validators.nl_NL.xliff
+++ b/app/Resources/translations/validators.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-08-12T13:45:11Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2016-11-03T10:45:46Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -8,11 +8,12 @@
     <body>
       <trans-unit id="e921db3beb8170142aa4dcd8c364595343b6fc64" resname="middleware_client.dto.configuration.show_raa_contact_information.must_be_boolean">
         <source>middleware_client.dto.configuration.show_raa_contact_information.must_be_boolean</source>
-        <target state="new">middleware_client.dto.configuration.show_raa_contact_information.must_be_boolean</target>
+        <target>Show RAA Contact Information option must be boolean.</target>
       </trans-unit>
       <trans-unit id="53ef4f54259698cee5e0aaba2d7f20417cd8e9fb" resname="middleware_client.dto.configuration.use_ra_locations.must_be_boolean">
         <source>middleware_client.dto.configuration.use_ra_locations.must_be_boolean</source>
-        <target state="new">middleware_client.dto.configuration.use_ra_locations.must_be_boolean</target>
+        <target>Use RA locations option must be boolean.
+</target>
       </trans-unit>
       <trans-unit id="f033a6177f4f371fbc302f07a6b8c67ec8b46549" resname="middleware_client.dto.identity.common_name.must_be_string">
         <source>middleware_client.dto.identity.common_name.must_be_string</source>

--- a/app/Resources/translations/validators.nl_NL.xliff
+++ b/app/Resources/translations/validators.nl_NL.xliff
@@ -431,6 +431,14 @@
         <source>ra.verify_identity_command.document_number.may_not_be_empty</source>
         <target>Voor de laatste 6 karakters van het documentnummer in</target>
       </trans-unit>
+      <trans-unit id="94785a2a9091f214657771372fcb4a61d47948bd" resname="ra.verify_identity_command.document_number.must_be_higher_than_minimum">
+        <source>ra.verify_identity_command.document_number.must_be_higher_than_minimum</source>
+        <target>Documentnummer moet uit ten minste {{ limit }} teken bestaan.|Documentnummer moet uit ten minste {{ limit }} tekens bestaan.</target>
+      </trans-unit>
+      <trans-unit id="5b10a05ddf6d1e4e7073de3dbbde2c7a095870ff" resname="ra.verify_identity_command.document_number.must_be_lower_than_maximum">
+        <source>ra.verify_identity_command.document_number.must_be_lower_than_maximum</source>
+        <target>Documentnummer mag uit ten hoogste {{ limit }} teken bestaan.|Documentnummer mag uit ten hoogste {{ limit }} tekens bestaan.</target>
+      </trans-unit>
       <trans-unit id="6a7721edc1618980a3d081cf8df1585ec10018ec" resname="ra.verify_identity_command.document_number.must_be_string">
         <source>ra.verify_identity_command.document_number.must_be_string</source>
         <target>Voor de laatste 6 karakters van het documentnummer in</target>

--- a/src/Surfnet/StepupRa/RaBundle/Command/VerifyIdentityCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/VerifyIdentityCommand.php
@@ -25,6 +25,12 @@ class VerifyIdentityCommand
     /**
      * @Assert\NotBlank(message="ra.verify_identity_command.document_number.may_not_be_empty")
      * @Assert\Type(type="string", message="ra.verify_identity_command.document_number.must_be_string")
+     * @Assert\Length(
+     *      min=1,
+     *      max=6,
+     *      minMessage="ra.verify_identity_command.document_number.must_be_higher_than_minimum",
+     *      maxMessage="ra.verify_identity_command.document_number.must_be_lower_than_maximum"
+     * )
      *
      * @var string
      */

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupRa\RaBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
 
 class VerifyIdentityType extends AbstractType
 {
@@ -28,6 +29,7 @@ class VerifyIdentityType extends AbstractType
     {
         $builder->add('documentNumber', 'text', [
             'label' => 'ra.form.verify_identity.document_number.label',
+            'constraints' => new Length(6),
             'horizontal_label_class' => 'col-sm-6 left-aligned',
             'horizontal_input_wrapper_class' => 'col-sm-6',
             'attr' => [

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
@@ -35,6 +35,8 @@ class VerifyIdentityType extends AbstractType
             'attr' => [
                 'autofocus' => true,
                 'autocomplete' => 'off',
+                'minlength' => 6,
+                'maxlength' => 6
             ]
         ]);
         $builder->add('identityVerified', 'checkbox', [

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
@@ -29,14 +29,13 @@ class VerifyIdentityType extends AbstractType
     {
         $builder->add('documentNumber', 'text', [
             'label' => 'ra.form.verify_identity.document_number.label',
-            'constraints' => new Length(6),
             'horizontal_label_class' => 'col-sm-6 left-aligned',
             'horizontal_input_wrapper_class' => 'col-sm-6',
             'attr' => [
                 'autofocus' => true,
                 'autocomplete' => 'off',
-                'minlength' => 6,
-                'maxlength' => 6
+                'maxlength' => 6,
+                'novalidate' => true
             ]
         ]);
         $builder->add('identityVerified', 'checkbox', [


### PR DESCRIPTION
[86104518](https://www.pivotaltracker.com/story/show/86104518)

In PHP, a constraint has been added to document number input of the verify identity form. 

<img width="755" alt="screen shot 2016-11-01 at 16 22 36" src="https://cloud.githubusercontent.com/assets/3816591/19896739/9fc2e85e-a055-11e6-88ac-01ac1bd35a15.png">

*EDIT: the validation text has since this image been customised and translated, it will give separate messages for numbers < 1 (if the user somehow manages to post that) and for numbers > 6*

