### PR TITLE
Correct audit log ordering

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -127,9 +127,9 @@
         <source>ra.auditlog.no_entries</source>
         <target>No records have been found in the audit log</target>
       </trans-unit>
-      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_id">
+      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_identifier">
         <jms:reference-file line="22">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.second_factor_id</source>
+        <source>ra.auditlog.second_factor_identifier</source>
         <target>Token Identifier</target>
       </trans-unit>
       <trans-unit id="9d81b131675cde2dcecc00c77cdebcc85c55fb5b" resname="ra.auditlog.second_factor_type">

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -32,9 +32,9 @@
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
       </trans-unit>
-      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.action">
+      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.event">
         <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.action</source>
+        <source>ra.auditlog.event</source>
         <target>Event</target>
       </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -127,9 +127,9 @@
         <source>ra.auditlog.no_entries</source>
         <target>Er zijn geen records in de audit log gevonden</target>
       </trans-unit>
-      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_id">
+      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_identifier">
         <jms:reference-file line="22">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.second_factor_id</source>
+        <source>ra.auditlog.second_factor_identifier</source>
         <target>Token identifier</target>
       </trans-unit>
       <trans-unit id="9d81b131675cde2dcecc00c77cdebcc85c55fb5b" resname="ra.auditlog.second_factor_type">

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -32,9 +32,9 @@
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
       </trans-unit>
-      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.action">
+      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.event">
         <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.action</source>
+        <source>ra.auditlog.event</source>
         <target>Gebeurtenis</target>
       </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
@@ -21,7 +21,7 @@
                 <tr>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.second_factor_id'|trans, 'secondFactorIdentifier') }}</th>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.second_factor_type'|trans, 'secondFactorType') }}</th>
-                    <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.action'|trans, 'event') }}</th>
+                    <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.event'|trans, 'event') }}</th>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.when'|trans, 'recordedOn') }}</th>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.actor'|trans, 'actorCommonName') }}</th>
                 </tr>

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
@@ -21,7 +21,7 @@
                 <tr>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.second_factor_id'|trans, 'secondFactorIdentifier') }}</th>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.second_factor_type'|trans, 'secondFactorType') }}</th>
-                    <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.action'|trans, 'action') }}</th>
+                    <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.action'|trans, 'event') }}</th>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.when'|trans, 'recordedOn') }}</th>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.actor'|trans, 'actorCommonName') }}</th>
                 </tr>

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
@@ -19,7 +19,7 @@
         <table class="table table-striped table-hover">
             <thead>
                 <tr>
-                    <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.second_factor_id'|trans, 'secondFactorIdentifier') }}</th>
+                    <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.second_factor_identifier'|trans, 'secondFactorIdentifier') }}</th>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.second_factor_type'|trans, 'secondFactorType') }}</th>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.event'|trans, 'event') }}</th>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.when'|trans, 'recordedOn') }}</th>


### PR DESCRIPTION
[133246727](https://www.pivotaltracker.com/story/show/133246727)

This makes sure the correct ordering names are used to order the audit log by.
This also makes the translation keys for "events" and "second_factor_identifier" less confusing.

### Related
SURFnet/Stepup-Middleware#158