### PR TITLE
Communicate error when RA vets outside his institution

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-11-08T14:19:10Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2016-11-25T14:36:10Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -31,11 +31,6 @@
         <jms:reference-file line="3">Resources/views/translations.twig</jms:reference-file>
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
-      </trans-unit>
-      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.event">
-        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.event</source>
-        <target>Event</target>
       </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">
         <jms:reference-file line="62">Resources/views/translations.html.twig</jms:reference-file>
@@ -122,12 +117,17 @@
         <source>ra.auditlog.email</source>
         <target>E-mail</target>
       </trans-unit>
+      <trans-unit id="5f6db090607f031547304b8d4eaaf0b57c9a76a9" resname="ra.auditlog.event">
+        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
+        <source>ra.auditlog.event</source>
+        <target>Event</target>
+      </trans-unit>
       <trans-unit id="8a542621cac70df8e15d200c8bd2f2b650663849" resname="ra.auditlog.no_entries">
         <jms:reference-file line="44">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.no_entries</source>
         <target>No records have been found in the audit log</target>
       </trans-unit>
-      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_identifier">
+      <trans-unit id="5e0d6e050bc563d5e4b8f419651120cd8f250825" resname="ra.auditlog.second_factor_identifier">
         <jms:reference-file line="22">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.second_factor_identifier</source>
         <target>Token Identifier</target>
@@ -1116,12 +1116,18 @@
         <source>ra.sraa.changed_institution</source>
         <target>Your institution has been changed to "%institution%"</target>
       </trans-unit>
+      <trans-unit id="2c1d6651fe44a724bafa00301191bc7ffa19e27c" resname="ra.verify_identity.different_institution_error">
+        <jms:reference-file line="220">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <source>ra.verify_identity.different_institution_error</source>
+        <target>Registrant cannot be vetted: he is with a different institution</target>
+      </trans-unit>
       <trans-unit id="abe2e824031a2393db11918365a49cf65d3ec585" resname="ra.verify_identity.identity_verification_failed">
         <jms:reference-file line="8">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.identity_verification_failed</source>
         <target>Identity verification failed</target>
       </trans-unit>
       <trans-unit id="eff2ebc67229b22b80526799953593c40a2c6ef9" resname="ra.verify_identity.registration_code_expired">
+        <jms:reference-file line="227">RaBundle/Controller/VettingController.php</jms:reference-file>
         <jms:reference-file line="9">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.registration_code_expired</source>
         <target>The activation code has expired. First, delete the current token registration of the user (by RA or user). The user then starts a new registration on %self_service_url% and will receive a new activation code that is valid for 14 days.</target>
@@ -1153,8 +1159,8 @@
       </trans-unit>
       <trans-unit id="32b7bc724e0d07eac8325753ae89605966b495c7" resname="ra.vetting.flash.cancelled">
         <jms:reference-file line="120">Controller/Vetting/SmsController.php</jms:reference-file>
-        <jms:reference-file line="144">RaBundle/Controller/VettingController.php</jms:reference-file>
-        <jms:reference-file line="174">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="145">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="175">RaBundle/Controller/VettingController.php</jms:reference-file>
         <source>ra.vetting.flash.cancelled</source>
         <target>The vetting procedure was cancelled.</target>
       </trans-unit>
@@ -1244,7 +1250,7 @@
         <target>Token type disabled</target>
       </trans-unit>
       <trans-unit id="8e4a356a46fe95b04ae1cbb201b8d62e15670b2e" resname="ra.vetting.sms.challenge_body">
-        <jms:reference-file line="216">RaBundle/Service/VettingService.php</jms:reference-file>
+        <jms:reference-file line="217">RaBundle/Service/VettingService.php</jms:reference-file>
         <source>ra.vetting.sms.challenge_body</source>
         <target>Your code: %challenge%</target>
       </trans-unit>

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -438,7 +438,7 @@
       <trans-unit id="a585bcd548874097afa817682427ed94ce28ab10" resname="ra.form.start_vetting_procedure.different_institution_error">
         <jms:reference-file line="5">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.start_vetting_procedure.different_institution_error</source>
-        <target>The found registration code belongs to a user with a different institution than the RA's.</target>
+        <target>This activation code belongs to a user from another home institution. You are not authorized to activate the token of this user. Please refer the user to the Service Desk of his home institution to have his token activated.</target>
       </trans-unit>
       <trans-unit id="bc646760865688482dd10d1f7bf383e3cf68b349" resname="ra.form.start_vetting_procedure.enter_activation_code_here">
         <jms:reference-file line="7">Resources/views/translations.html.twig</jms:reference-file>

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-11-25T14:36:10Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2016-11-08T14:19:10Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -31,6 +31,11 @@
         <jms:reference-file line="3">Resources/views/translations.twig</jms:reference-file>
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
+      </trans-unit>
+      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.event">
+        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
+        <source>ra.auditlog.event</source>
+        <target>Event</target>
       </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">
         <jms:reference-file line="62">Resources/views/translations.html.twig</jms:reference-file>
@@ -117,17 +122,12 @@
         <source>ra.auditlog.email</source>
         <target>E-mail</target>
       </trans-unit>
-      <trans-unit id="5f6db090607f031547304b8d4eaaf0b57c9a76a9" resname="ra.auditlog.event">
-        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.event</source>
-        <target>Event</target>
-      </trans-unit>
       <trans-unit id="8a542621cac70df8e15d200c8bd2f2b650663849" resname="ra.auditlog.no_entries">
         <jms:reference-file line="44">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.no_entries</source>
         <target>No records have been found in the audit log</target>
       </trans-unit>
-      <trans-unit id="5e0d6e050bc563d5e4b8f419651120cd8f250825" resname="ra.auditlog.second_factor_identifier">
+      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_identifier">
         <jms:reference-file line="22">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.second_factor_identifier</source>
         <target>Token Identifier</target>
@@ -1116,18 +1116,12 @@
         <source>ra.sraa.changed_institution</source>
         <target>Your institution has been changed to "%institution%"</target>
       </trans-unit>
-      <trans-unit id="2c1d6651fe44a724bafa00301191bc7ffa19e27c" resname="ra.verify_identity.different_institution_error">
-        <jms:reference-file line="220">RaBundle/Controller/VettingController.php</jms:reference-file>
-        <source>ra.verify_identity.different_institution_error</source>
-        <target>Registrant cannot be vetted: he is with a different institution</target>
-      </trans-unit>
       <trans-unit id="abe2e824031a2393db11918365a49cf65d3ec585" resname="ra.verify_identity.identity_verification_failed">
         <jms:reference-file line="8">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.identity_verification_failed</source>
         <target>Identity verification failed</target>
       </trans-unit>
       <trans-unit id="eff2ebc67229b22b80526799953593c40a2c6ef9" resname="ra.verify_identity.registration_code_expired">
-        <jms:reference-file line="227">RaBundle/Controller/VettingController.php</jms:reference-file>
         <jms:reference-file line="9">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.registration_code_expired</source>
         <target>The activation code has expired. First, delete the current token registration of the user (by RA or user). The user then starts a new registration on %self_service_url% and will receive a new activation code that is valid for 14 days.</target>
@@ -1159,8 +1153,8 @@
       </trans-unit>
       <trans-unit id="32b7bc724e0d07eac8325753ae89605966b495c7" resname="ra.vetting.flash.cancelled">
         <jms:reference-file line="120">Controller/Vetting/SmsController.php</jms:reference-file>
-        <jms:reference-file line="145">RaBundle/Controller/VettingController.php</jms:reference-file>
-        <jms:reference-file line="175">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="144">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="174">RaBundle/Controller/VettingController.php</jms:reference-file>
         <source>ra.vetting.flash.cancelled</source>
         <target>The vetting procedure was cancelled.</target>
       </trans-unit>
@@ -1250,7 +1244,7 @@
         <target>Token type disabled</target>
       </trans-unit>
       <trans-unit id="8e4a356a46fe95b04ae1cbb201b8d62e15670b2e" resname="ra.vetting.sms.challenge_body">
-        <jms:reference-file line="217">RaBundle/Service/VettingService.php</jms:reference-file>
+        <jms:reference-file line="216">RaBundle/Service/VettingService.php</jms:reference-file>
         <source>ra.vetting.sms.challenge_body</source>
         <target>Your code: %challenge%</target>
       </trans-unit>

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-11-08T14:19:10Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2016-11-25T16:20:09Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -32,78 +32,73 @@
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
       </trans-unit>
-      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.event">
-        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.event</source>
-        <target>Event</target>
-      </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">
-        <jms:reference-file line="62">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="63">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.accredited_as_ra</source>
         <target>Accredited as RA</target>
       </trans-unit>
       <trans-unit id="66b320bfe1f15eabe6e0baa04e94b71c2152f8e2" resname="ra.auditlog.action.accredited_as_raa">
-        <jms:reference-file line="63">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="64">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.accredited_as_raa</source>
         <target>Accredited as RAA</target>
       </trans-unit>
       <trans-unit id="ba50c2f5a7066cd14d8ae1f33c5f4decc892d0b7" resname="ra.auditlog.action.appointed_as_ra">
-        <jms:reference-file line="64">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="65">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.appointed_as_ra</source>
         <target>Appointed as RA</target>
       </trans-unit>
       <trans-unit id="f1a9c08794cd9c91a7f63841cc1c9ff61c3da452" resname="ra.auditlog.action.appointed_as_raa">
-        <jms:reference-file line="65">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="66">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.appointed_as_raa</source>
         <target>Appointed as RAA</target>
       </trans-unit>
       <trans-unit id="9c05a55d8f3ef06afe4f9d81883c0cd6dc415933" resname="ra.auditlog.action.bootstrapped">
-        <jms:reference-file line="61">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="62">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.bootstrapped</source>
         <target>Identity and Token bootstrapped</target>
       </trans-unit>
       <trans-unit id="c9199d83adb7c6ebeaa6cfe08d2fc57f308677a9" resname="ra.auditlog.action.created">
-        <jms:reference-file line="56">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="57">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.created</source>
         <target>Identity Created</target>
       </trans-unit>
       <trans-unit id="f2264e8a139e432bc0b30abd24ab34750e944da0" resname="ra.auditlog.action.email_changed">
-        <jms:reference-file line="57">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="58">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.email_changed</source>
         <target>E-mail changed</target>
       </trans-unit>
       <trans-unit id="8750a7f384fd2159c68613b478b283083c45f8fa" resname="ra.auditlog.action.email_verified">
-        <jms:reference-file line="54">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="55">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.email_verified</source>
         <target>E-mail verified</target>
       </trans-unit>
       <trans-unit id="59b375a103f9bff34d2da25cb0563524354b357d" resname="ra.auditlog.action.possession_proven">
-        <jms:reference-file line="55">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="56">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.possession_proven</source>
         <target>Token possession proven</target>
       </trans-unit>
       <trans-unit id="6182cba621f2930f0600729d0cf846477b645851" resname="ra.auditlog.action.renamed">
-        <jms:reference-file line="58">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="59">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.renamed</source>
         <target>Name changed</target>
       </trans-unit>
       <trans-unit id="625f464c28c526a1fb856c5c6c8387e8d4c49518" resname="ra.auditlog.action.retracted_as_ra">
-        <jms:reference-file line="66">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="67">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.retracted_as_ra</source>
         <target>Removed as RA(A)</target>
       </trans-unit>
       <trans-unit id="3b4520b328a4b841d468fd967962d674db2d2947" resname="ra.auditlog.action.revoked">
-        <jms:reference-file line="60">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="61">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.revoked</source>
         <target>Token revoked</target>
       </trans-unit>
       <trans-unit id="cfa1707c5ee601824695a03199bac938cbac9a62" resname="ra.auditlog.action.revoked_by_ra">
-        <jms:reference-file line="53">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="54">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.revoked_by_ra</source>
         <target>Token revoked by RA</target>
       </trans-unit>
       <trans-unit id="0685bbf771d00c304c5807c48e34ba0c8b73b3eb" resname="ra.auditlog.action.vetted">
-        <jms:reference-file line="59">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="60">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.vetted</source>
         <target>Token vetted</target>
       </trans-unit>
@@ -122,12 +117,17 @@
         <source>ra.auditlog.email</source>
         <target>E-mail</target>
       </trans-unit>
+      <trans-unit id="5f6db090607f031547304b8d4eaaf0b57c9a76a9" resname="ra.auditlog.event">
+        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
+        <source>ra.auditlog.event</source>
+        <target>Event</target>
+      </trans-unit>
       <trans-unit id="8a542621cac70df8e15d200c8bd2f2b650663849" resname="ra.auditlog.no_entries">
         <jms:reference-file line="44">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.no_entries</source>
         <target>No records have been found in the audit log</target>
       </trans-unit>
-      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_identifier">
+      <trans-unit id="5e0d6e050bc563d5e4b8f419651120cd8f250825" resname="ra.auditlog.second_factor_identifier">
         <jms:reference-file line="22">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.second_factor_identifier</source>
         <target>Token Identifier</target>
@@ -285,12 +285,12 @@
         <target>Due to an unknown reason, switching locales failed.</target>
       </trans-unit>
       <trans-unit id="c73b11f71b8ad5d46b3e42e649919aee4bc9ece5" resname="ra.form.extension.ra_role_choice.ra">
-        <jms:reference-file line="49">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="50">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.extension.ra_role_choice.ra</source>
         <target>RA</target>
       </trans-unit>
       <trans-unit id="e55aa3fd11b0cd43d84e2e3e41be6729e7fc35f0" resname="ra.form.extension.ra_role_choice.raa">
-        <jms:reference-file line="50">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="51">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.extension.ra_role_choice.raa</source>
         <target>RAA</target>
       </trans-unit>
@@ -435,13 +435,18 @@
         <source>ra.form.ra_verify_phone_number.text.challenge</source>
         <target>Code</target>
       </trans-unit>
+      <trans-unit id="a585bcd548874097afa817682427ed94ce28ab10" resname="ra.form.start_vetting_procedure.different_institution_error">
+        <jms:reference-file line="5">Resources/views/translations.html.twig</jms:reference-file>
+        <source>ra.form.start_vetting_procedure.different_institution_error</source>
+        <target>The found registration code belongs to a user with a different institution than the RA's.</target>
+      </trans-unit>
       <trans-unit id="bc646760865688482dd10d1f7bf383e3cf68b349" resname="ra.form.start_vetting_procedure.enter_activation_code_here">
-        <jms:reference-file line="6">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.start_vetting_procedure.enter_activation_code_here</source>
         <target>Activation code...</target>
       </trans-unit>
       <trans-unit id="823c5d1536401e73cf7bda2e291fd21bdb207f96" resname="ra.form.start_vetting_procedure.loa_insufficient">
-        <jms:reference-file line="5">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.start_vetting_procedure.loa_insufficient</source>
         <target>You don't have the security clearance to vet the token that matches this registration code.</target>
       </trans-unit>
@@ -471,7 +476,7 @@
         <target>Verify identity</target>
       </trans-unit>
       <trans-unit id="584ef35d6af2f2917e708a1a6092f0b0938151e4" resname="ra.management.amend_ra_info.error.middleware_command_failed">
-        <jms:reference-file line="73">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="74">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.amend_ra_info.error.middleware_command_failed</source>
         <target>The amendment of the RA's information failed due to a server error.</target>
       </trans-unit>
@@ -559,7 +564,7 @@
         <target>The Registration Authority has been granted the selected role</target>
       </trans-unit>
       <trans-unit id="f2d212150076ce42ffe47d514f182ad5e7a6c9fe" resname="ra.management.create_ra.error.middleware_command_failed">
-        <jms:reference-file line="72">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="73">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.create_ra.error.middleware_command_failed</source>
         <target>The identity could not be granted the chosen role due to a server error.</target>
       </trans-unit>
@@ -735,17 +740,17 @@
         <target>Role</target>
       </trans-unit>
       <trans-unit id="64d8691325da6d2b996fd48f7da7a382fdeb22e7" resname="ra.management.overview.role.value.ra">
-        <jms:reference-file line="69">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="70">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.overview.role.value.ra</source>
         <target>RA</target>
       </trans-unit>
       <trans-unit id="ac982ab35b7b5438a72cb6e243975c8ddd35e148" resname="ra.management.overview.role.value.raa">
-        <jms:reference-file line="70">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.overview.role.value.raa</source>
         <target>RAA</target>
       </trans-unit>
       <trans-unit id="53c4452d09c417bfb728d1e738b2ae2bbff3c883" resname="ra.management.overview.role.value.sraa">
-        <jms:reference-file line="71">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="72">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.overview.role.value.sraa</source>
         <target>SRAA</target>
       </trans-unit>
@@ -825,22 +830,22 @@
         <target>change</target>
       </trans-unit>
       <trans-unit id="ff49fbf3684f01850a026abeff8b6f3cd6d89a98" resname="ra.prove_phone_possession.challenge_expired">
-        <jms:reference-file line="25">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.prove_phone_possession.challenge_expired</source>
         <target>Your code has expired. Please request a new code.</target>
       </trans-unit>
       <trans-unit id="f4e4a44fa84430b2d144a6dee71c69e914a963dd" resname="ra.prove_phone_possession.challenge_response_incorrect">
-        <jms:reference-file line="24">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="25">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.prove_phone_possession.challenge_response_incorrect</source>
         <target>This code is not correct. Please try again or request a new code.</target>
       </trans-unit>
       <trans-unit id="0d9cb3b18021e2899cf1031812da9a489b60093d" resname="ra.prove_phone_possession.too_many_attempts">
-        <jms:reference-file line="26">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.prove_phone_possession.too_many_attempts</source>
         <target>You have exceeded the limit of ten attempts; you can no longer attempt verification of any more codes. Contact your helpdesk or try again later.</target>
       </trans-unit>
       <trans-unit id="06ada20a09df4484b41e75a58e813b54d4904f33" resname="ra.prove_yubikey_possession.different_yubikey_used">
-        <jms:reference-file line="20">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.prove_yubikey_possession.different_yubikey_used</source>
         <target>A different Yubikey was used by the user during the registration process.</target>
       </trans-unit>
@@ -1032,22 +1037,22 @@
         <target>Type</target>
       </trans-unit>
       <trans-unit id="5396da3d169284da408b7e41c919fc3cbb0a7789" resname="ra.second_factor.search.status.revoked">
-        <jms:reference-file line="36">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="37">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.status.revoked</source>
         <target>Removed</target>
       </trans-unit>
       <trans-unit id="b95f6a983c4cb565e06b2b444afd9e53737e41d7" resname="ra.second_factor.search.status.unverified">
-        <jms:reference-file line="33">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="34">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.status.unverified</source>
         <target>Not verified</target>
       </trans-unit>
       <trans-unit id="342a7ca495a8ab8baf8c65ca63c53558cb01688d" resname="ra.second_factor.search.status.verified">
-        <jms:reference-file line="34">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.status.verified</source>
         <target>Verified</target>
       </trans-unit>
       <trans-unit id="876f09e852960f57e319006c49585af1bbd55a84" resname="ra.second_factor.search.status.vetted">
-        <jms:reference-file line="35">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="36">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.status.vetted</source>
         <target>Activated</target>
       </trans-unit>
@@ -1062,22 +1067,22 @@
         <target>Security tokens</target>
       </trans-unit>
       <trans-unit id="e806f4c23b643c67a31167df8119efee18fae7a6" resname="ra.second_factor.search.type.sms">
-        <jms:reference-file line="29">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="30">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.type.sms</source>
         <target>SMS</target>
       </trans-unit>
       <trans-unit id="681292ebf2622b5e28a501e75394f550688e0ee4" resname="ra.second_factor.search.type.tiqr">
-        <jms:reference-file line="31">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="32">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.type.tiqr</source>
         <target>Tiqr</target>
       </trans-unit>
       <trans-unit id="7c92f246db43cf7cf51f891825e9ac95422ec7ef" resname="ra.second_factor.search.type.u2f">
-        <jms:reference-file line="32">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="33">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.type.u2f</source>
         <target>U2F</target>
       </trans-unit>
       <trans-unit id="85d8e5c7803600b08c39830c29a12bee3aa97146" resname="ra.second_factor.search.type.yubikey">
-        <jms:reference-file line="30">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.type.yubikey</source>
         <target>Yubikey</target>
       </trans-unit>
@@ -1107,7 +1112,7 @@
         <target>Session Expired</target>
       </trans-unit>
       <trans-unit id="a718fae8b5a05ddfe4f55f3ed1a4bb8b365ea12c" resname="ra.sms_send_challenge.send_sms_challenge_failed">
-        <jms:reference-file line="23">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.sms_send_challenge.send_sms_challenge_failed</source>
         <target>The sending of the code via SMS failed.</target>
       </trans-unit>
@@ -1117,27 +1122,28 @@
         <target>Your institution has been changed to "%institution%"</target>
       </trans-unit>
       <trans-unit id="abe2e824031a2393db11918365a49cf65d3ec585" resname="ra.verify_identity.identity_verification_failed">
-        <jms:reference-file line="8">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="9">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.identity_verification_failed</source>
         <target>Identity verification failed</target>
       </trans-unit>
       <trans-unit id="eff2ebc67229b22b80526799953593c40a2c6ef9" resname="ra.verify_identity.registration_code_expired">
-        <jms:reference-file line="9">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="228">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="10">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.registration_code_expired</source>
         <target>The activation code has expired. First, delete the current token registration of the user (by RA or user). The user then starts a new registration on %self_service_url% and will receive a new activation code that is valid for 14 days.</target>
       </trans-unit>
       <trans-unit id="ba1980036b712688f6681fb8f86ac6925a1cba5a" resname="ra.verify_identity.second_factor_vetting_failed">
-        <jms:reference-file line="7">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="8">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.second_factor_vetting_failed</source>
         <target>The security token could not be vetted due to unknown reasons.</target>
       </trans-unit>
       <trans-unit id="7b8f4a813ad65c5f70c2f28e3459db2300aa11d8" resname="ra.verify_yubikey_command.otp.otp_invalid">
-        <jms:reference-file line="18">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_yubikey_command.otp.otp_invalid</source>
         <target>The Yubikey code was invalid. Please try again.</target>
       </trans-unit>
       <trans-unit id="669fe8c5f63adab894fc62f2bbf036f2fe9e8b6c" resname="ra.verify_yubikey_command.otp.verification_error">
-        <jms:reference-file line="19">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_yubikey_command.otp.verification_error</source>
         <target>The Yubikey code could not be verified due to unknown reasons.</target>
       </trans-unit>
@@ -1153,48 +1159,48 @@
       </trans-unit>
       <trans-unit id="32b7bc724e0d07eac8325753ae89605966b495c7" resname="ra.vetting.flash.cancelled">
         <jms:reference-file line="120">Controller/Vetting/SmsController.php</jms:reference-file>
-        <jms:reference-file line="144">RaBundle/Controller/VettingController.php</jms:reference-file>
-        <jms:reference-file line="174">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="154">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="184">RaBundle/Controller/VettingController.php</jms:reference-file>
         <source>ra.vetting.flash.cancelled</source>
         <target>The vetting procedure was cancelled.</target>
       </trans-unit>
       <trans-unit id="1dec0b54fa1739f15b995a5a8a3acb03adeff07d" resname="ra.vetting.gssf.initiate.biometric.button.initiate">
-        <jms:reference-file line="45">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="46">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.biometric.button.initiate</source>
         <target>Verify biometrics</target>
       </trans-unit>
       <trans-unit id="94b9f4e4392a0b3cdf5cff65cf8951cb2ee4b3ba" resname="ra.vetting.gssf.initiate.biometric.error.gssf_id_mismatch">
-        <jms:reference-file line="46">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="47">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.biometric.error.gssf_id_mismatch</source>
         <target>The biometric device returned a different ID than was registered in the Self-Service application.</target>
       </trans-unit>
       <trans-unit id="900abec75af2dfb739b1f7a9e73695385893b0d0" resname="ra.vetting.gssf.initiate.biometric.text.explanation">
-        <jms:reference-file line="44">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="45">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.biometric.text.explanation</source>
         <target>Click the button below to verify the registrant biometrically.</target>
       </trans-unit>
       <trans-unit id="ee546154768e6aa0c5075029912a2b01d7cd5ab6" resname="ra.vetting.gssf.initiate.biometric.title.page">
-        <jms:reference-file line="43">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="44">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.biometric.title.page</source>
         <target>Verify biometrics</target>
       </trans-unit>
       <trans-unit id="485287b4d4e2f13a9df979601799e727821b9817" resname="ra.vetting.gssf.initiate.tiqr.button.initiate">
-        <jms:reference-file line="41">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="42">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.tiqr.button.initiate</source>
         <target>Verify with Tiqr</target>
       </trans-unit>
       <trans-unit id="e6ca047d4a5ae812276be6e8ece30cc7d6102af2" resname="ra.vetting.gssf.initiate.tiqr.error.gssf_id_mismatch">
-        <jms:reference-file line="42">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="43">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.tiqr.error.gssf_id_mismatch</source>
         <target>The Tiqr server responded with an ID that doesn't match the requested ID the registrant registered with using the Self-Service application.</target>
       </trans-unit>
       <trans-unit id="a5ec286b6d7f1ba6056eb720211d748ca9e8844c" resname="ra.vetting.gssf.initiate.tiqr.text.explanation">
-        <jms:reference-file line="40">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="41">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.tiqr.text.explanation</source>
         <target>Click the button below to verify the registrant owns the Tiqr account he or she registered with in the Self-Service application.</target>
       </trans-unit>
       <trans-unit id="cb3ffa7493a6cbda2c134ee5c2b80f193f822737" resname="ra.vetting.gssf.initiate.tiqr.title.page">
-        <jms:reference-file line="39">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="40">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.tiqr.title.page</source>
         <target>Verify with Tiqr</target>
       </trans-unit>
@@ -1219,22 +1225,22 @@
         <target>Verify identity</target>
       </trans-unit>
       <trans-unit id="f264bf655086664d56fe4803d21b31286b15d6ec" resname="ra.vetting.second_factor_type_disabled.text.explanation.sms">
-        <jms:reference-file line="12">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.second_factor_type_disabled.text.explanation.sms</source>
         <target>The token type SMS is currently disabled. Please contact your helpdesk to correct this problem.</target>
       </trans-unit>
       <trans-unit id="ef613fe71984bbd610ab57eaa7c0e99bf780ac4b" resname="ra.vetting.second_factor_type_disabled.text.explanation.tiqr">
-        <jms:reference-file line="14">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="15">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.second_factor_type_disabled.text.explanation.tiqr</source>
         <target>The token type Tiqr is currently disabled. Please contact your helpdesk to correct this problem.</target>
       </trans-unit>
       <trans-unit id="81f416a526dd1635fe0d3c1db52d1f4c2cb99b8a" resname="ra.vetting.second_factor_type_disabled.text.explanation.u2f">
-        <jms:reference-file line="15">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="16">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.second_factor_type_disabled.text.explanation.u2f</source>
         <target>The token type U2F is currently disabled. Please contact your helpdesk to correct this problem.</target>
       </trans-unit>
       <trans-unit id="cf1e0f5a486105a8a24c5039a153454148398375" resname="ra.vetting.second_factor_type_disabled.text.explanation.yubikey">
-        <jms:reference-file line="13">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="14">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.second_factor_type_disabled.text.explanation.yubikey</source>
         <target>The token type Yubikey is currently disabled. Please contact your helpdesk to correct this problem.</target>
       </trans-unit>
@@ -1294,12 +1300,12 @@
         <target>Home</target>
       </trans-unit>
       <trans-unit id="385d56fffaf0e844dcd7b164b18741f050ba28e7" resname="ra.vetting.u2f.alert.device_reported_an_error">
-        <jms:reference-file line="76">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="77">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.u2f.alert.device_reported_an_error</source>
         <target>The U2F device reported an error. Try again or visit your IT helpdesk.</target>
       </trans-unit>
       <trans-unit id="467eb86ef7b096d0e14386714ef1b120c3f6b834" resname="ra.vetting.u2f.alert.error">
-        <jms:reference-file line="77">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="78">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.u2f.alert.error</source>
         <target>The authentication using the U2F device failed. Try again or visit your IT helpdesk.</target>
       </trans-unit>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -438,7 +438,7 @@
       <trans-unit id="a585bcd548874097afa817682427ed94ce28ab10" resname="ra.form.start_vetting_procedure.different_institution_error">
         <jms:reference-file line="5">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.start_vetting_procedure.different_institution_error</source>
-        <target>De gevonden verificatiecode hoort bij een gebruiker met een ander instituut dan die van de RA.</target>
+        <target>Deze activatiecode hoort bij een gebruiker van een andere instelling. U bent niet geautoriseerd om het token van deze gebruiker te activeren. Verwijs de gebruiker voor activatie van zijn token door naar de Service Desk van zijn eigen instelling.</target>
       </trans-unit>
       <trans-unit id="bc646760865688482dd10d1f7bf383e3cf68b349" resname="ra.form.start_vetting_procedure.enter_activation_code_here">
         <jms:reference-file line="7">Resources/views/translations.html.twig</jms:reference-file>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-11-25T14:35:48Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2016-11-08T14:27:42Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -31,6 +31,11 @@
         <jms:reference-file line="3">Resources/views/translations.twig</jms:reference-file>
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
+      </trans-unit>
+      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.event">
+        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
+        <source>ra.auditlog.event</source>
+        <target>Gebeurtenis</target>
       </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">
         <jms:reference-file line="62">Resources/views/translations.html.twig</jms:reference-file>
@@ -117,17 +122,12 @@
         <source>ra.auditlog.email</source>
         <target>E-mail</target>
       </trans-unit>
-      <trans-unit id="5f6db090607f031547304b8d4eaaf0b57c9a76a9" resname="ra.auditlog.event">
-        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.event</source>
-        <target>Gebeurtenis</target>
-      </trans-unit>
       <trans-unit id="8a542621cac70df8e15d200c8bd2f2b650663849" resname="ra.auditlog.no_entries">
         <jms:reference-file line="44">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.no_entries</source>
         <target>Er zijn geen records in de audit log gevonden</target>
       </trans-unit>
-      <trans-unit id="5e0d6e050bc563d5e4b8f419651120cd8f250825" resname="ra.auditlog.second_factor_identifier">
+      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_identifier">
         <jms:reference-file line="22">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.second_factor_identifier</source>
         <target>Token identifier</target>
@@ -1116,18 +1116,12 @@
         <source>ra.sraa.changed_institution</source>
         <target>Je instituut is veranderd naar "%institution%"</target>
       </trans-unit>
-      <trans-unit id="2c1d6651fe44a724bafa00301191bc7ffa19e27c" resname="ra.verify_identity.different_institution_error">
-        <jms:reference-file line="220">RaBundle/Controller/VettingController.php</jms:reference-file>
-        <source>ra.verify_identity.different_institution_error</source>
-        <target>Registrant kan niet gevet worden: hij zit bij een ander instituut</target>
-      </trans-unit>
       <trans-unit id="abe2e824031a2393db11918365a49cf65d3ec585" resname="ra.verify_identity.identity_verification_failed">
         <jms:reference-file line="8">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.identity_verification_failed</source>
         <target>De verificatie van de identiteit is mislukt</target>
       </trans-unit>
       <trans-unit id="eff2ebc67229b22b80526799953593c40a2c6ef9" resname="ra.verify_identity.registration_code_expired">
-        <jms:reference-file line="227">RaBundle/Controller/VettingController.php</jms:reference-file>
         <jms:reference-file line="9">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.registration_code_expired</source>
         <target>De activatie code is verlopen. Verwijder eerst de huidige token registratie (door RA of gebruiker). De gebruiker start vervolgens een nieuwe registratie via %self_service_url% en ontvangt een nieuwe activatiecode die weer 14 dagen geldig blijft.</target>
@@ -1159,8 +1153,8 @@
       </trans-unit>
       <trans-unit id="32b7bc724e0d07eac8325753ae89605966b495c7" resname="ra.vetting.flash.cancelled">
         <jms:reference-file line="120">Controller/Vetting/SmsController.php</jms:reference-file>
-        <jms:reference-file line="145">RaBundle/Controller/VettingController.php</jms:reference-file>
-        <jms:reference-file line="175">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="144">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="174">RaBundle/Controller/VettingController.php</jms:reference-file>
         <source>ra.vetting.flash.cancelled</source>
         <target>De activatieprocedure is afgebroken.</target>
       </trans-unit>
@@ -1250,7 +1244,7 @@
         <target>Tokentype uitgeschakeld</target>
       </trans-unit>
       <trans-unit id="8e4a356a46fe95b04ae1cbb201b8d62e15670b2e" resname="ra.vetting.sms.challenge_body">
-        <jms:reference-file line="217">RaBundle/Service/VettingService.php</jms:reference-file>
+        <jms:reference-file line="216">RaBundle/Service/VettingService.php</jms:reference-file>
         <source>ra.vetting.sms.challenge_body</source>
         <target>Uw SMS-code: %challenge%</target>
       </trans-unit>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-11-08T14:27:42Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2016-11-25T16:20:48Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -32,78 +32,73 @@
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
       </trans-unit>
-      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.event">
-        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.event</source>
-        <target>Gebeurtenis</target>
-      </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">
-        <jms:reference-file line="62">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="63">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.accredited_as_ra</source>
         <target>Geaccrediteerd als RA</target>
       </trans-unit>
       <trans-unit id="66b320bfe1f15eabe6e0baa04e94b71c2152f8e2" resname="ra.auditlog.action.accredited_as_raa">
-        <jms:reference-file line="63">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="64">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.accredited_as_raa</source>
         <target>Geaccrediteerd als RAA</target>
       </trans-unit>
       <trans-unit id="ba50c2f5a7066cd14d8ae1f33c5f4decc892d0b7" resname="ra.auditlog.action.appointed_as_ra">
-        <jms:reference-file line="64">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="65">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.appointed_as_ra</source>
         <target>RA rol toegewezen gekregen</target>
       </trans-unit>
       <trans-unit id="f1a9c08794cd9c91a7f63841cc1c9ff61c3da452" resname="ra.auditlog.action.appointed_as_raa">
-        <jms:reference-file line="65">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="66">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.appointed_as_raa</source>
         <target>RAA rol toegewezen gekregen</target>
       </trans-unit>
       <trans-unit id="9c05a55d8f3ef06afe4f9d81883c0cd6dc415933" resname="ra.auditlog.action.bootstrapped">
-        <jms:reference-file line="61">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="62">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.bootstrapped</source>
         <target>Identiteit en Token gebootstrapped</target>
       </trans-unit>
       <trans-unit id="c9199d83adb7c6ebeaa6cfe08d2fc57f308677a9" resname="ra.auditlog.action.created">
-        <jms:reference-file line="56">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="57">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.created</source>
         <target>Identiteit aangemaakt</target>
       </trans-unit>
       <trans-unit id="f2264e8a139e432bc0b30abd24ab34750e944da0" resname="ra.auditlog.action.email_changed">
-        <jms:reference-file line="57">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="58">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.email_changed</source>
         <target>E-mail gewijzigd</target>
       </trans-unit>
       <trans-unit id="8750a7f384fd2159c68613b478b283083c45f8fa" resname="ra.auditlog.action.email_verified">
-        <jms:reference-file line="54">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="55">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.email_verified</source>
         <target>E-mail geverifieerd</target>
       </trans-unit>
       <trans-unit id="59b375a103f9bff34d2da25cb0563524354b357d" resname="ra.auditlog.action.possession_proven">
-        <jms:reference-file line="55">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="56">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.possession_proven</source>
         <target>Bezit aangetoond</target>
       </trans-unit>
       <trans-unit id="6182cba621f2930f0600729d0cf846477b645851" resname="ra.auditlog.action.renamed">
-        <jms:reference-file line="58">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="59">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.renamed</source>
         <target>Naam gewijzigd</target>
       </trans-unit>
       <trans-unit id="625f464c28c526a1fb856c5c6c8387e8d4c49518" resname="ra.auditlog.action.retracted_as_ra">
-        <jms:reference-file line="66">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="67">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.retracted_as_ra</source>
         <target>Verwijderd als RA(A)</target>
       </trans-unit>
       <trans-unit id="3b4520b328a4b841d468fd967962d674db2d2947" resname="ra.auditlog.action.revoked">
-        <jms:reference-file line="60">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="61">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.revoked</source>
         <target>Token verwijderd</target>
       </trans-unit>
       <trans-unit id="cfa1707c5ee601824695a03199bac938cbac9a62" resname="ra.auditlog.action.revoked_by_ra">
-        <jms:reference-file line="53">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="54">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.revoked_by_ra</source>
         <target>Token verwijderd door RA</target>
       </trans-unit>
       <trans-unit id="0685bbf771d00c304c5807c48e34ba0c8b73b3eb" resname="ra.auditlog.action.vetted">
-        <jms:reference-file line="59">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="60">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.auditlog.action.vetted</source>
         <target>Token gevet</target>
       </trans-unit>
@@ -122,12 +117,17 @@
         <source>ra.auditlog.email</source>
         <target>E-mail</target>
       </trans-unit>
+      <trans-unit id="5f6db090607f031547304b8d4eaaf0b57c9a76a9" resname="ra.auditlog.event">
+        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
+        <source>ra.auditlog.event</source>
+        <target>Gebeurtenis</target>
+      </trans-unit>
       <trans-unit id="8a542621cac70df8e15d200c8bd2f2b650663849" resname="ra.auditlog.no_entries">
         <jms:reference-file line="44">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.no_entries</source>
         <target>Er zijn geen records in de audit log gevonden</target>
       </trans-unit>
-      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_identifier">
+      <trans-unit id="5e0d6e050bc563d5e4b8f419651120cd8f250825" resname="ra.auditlog.second_factor_identifier">
         <jms:reference-file line="22">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.second_factor_identifier</source>
         <target>Token identifier</target>
@@ -285,12 +285,12 @@
         <target>Het wisselen van taal is mislukt wegens een onbekende reden.</target>
       </trans-unit>
       <trans-unit id="c73b11f71b8ad5d46b3e42e649919aee4bc9ece5" resname="ra.form.extension.ra_role_choice.ra">
-        <jms:reference-file line="49">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="50">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.extension.ra_role_choice.ra</source>
         <target>RA</target>
       </trans-unit>
       <trans-unit id="e55aa3fd11b0cd43d84e2e3e41be6729e7fc35f0" resname="ra.form.extension.ra_role_choice.raa">
-        <jms:reference-file line="50">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="51">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.extension.ra_role_choice.raa</source>
         <target>RAA</target>
       </trans-unit>
@@ -435,13 +435,18 @@
         <source>ra.form.ra_verify_phone_number.text.challenge</source>
         <target>Code</target>
       </trans-unit>
+      <trans-unit id="a585bcd548874097afa817682427ed94ce28ab10" resname="ra.form.start_vetting_procedure.different_institution_error">
+        <jms:reference-file line="5">Resources/views/translations.html.twig</jms:reference-file>
+        <source>ra.form.start_vetting_procedure.different_institution_error</source>
+        <target>De gevonden verificatiecode hoort bij een gebruiker met een ander instituut dan die van de RA.</target>
+      </trans-unit>
       <trans-unit id="bc646760865688482dd10d1f7bf383e3cf68b349" resname="ra.form.start_vetting_procedure.enter_activation_code_here">
-        <jms:reference-file line="6">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.start_vetting_procedure.enter_activation_code_here</source>
         <target>Activatiecode...</target>
       </trans-unit>
       <trans-unit id="823c5d1536401e73cf7bda2e291fd21bdb207f96" resname="ra.form.start_vetting_procedure.loa_insufficient">
-        <jms:reference-file line="5">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.form.start_vetting_procedure.loa_insufficient</source>
         <target>U voldoet niet aan de veiligheidsvoorwaarden om dit token te activeren.</target>
       </trans-unit>
@@ -471,7 +476,7 @@
         <target>Verifieer identiteit</target>
       </trans-unit>
       <trans-unit id="584ef35d6af2f2917e708a1a6092f0b0938151e4" resname="ra.management.amend_ra_info.error.middleware_command_failed">
-        <jms:reference-file line="73">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="74">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.amend_ra_info.error.middleware_command_failed</source>
         <target>Het wijzigen van de gegevens van de RA is mislukt vanwege een serverfout.</target>
       </trans-unit>
@@ -559,7 +564,7 @@
         <target>De Registratie Authoriteit heeft de gekozen rol toegewezen gekregen</target>
       </trans-unit>
       <trans-unit id="f2d212150076ce42ffe47d514f182ad5e7a6c9fe" resname="ra.management.create_ra.error.middleware_command_failed">
-        <jms:reference-file line="72">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="73">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.create_ra.error.middleware_command_failed</source>
         <target>De gekozen rol kon niet aan de identiteit toegekend worden vanwege een serverfout.</target>
       </trans-unit>
@@ -735,17 +740,17 @@
         <target>Rol</target>
       </trans-unit>
       <trans-unit id="64d8691325da6d2b996fd48f7da7a382fdeb22e7" resname="ra.management.overview.role.value.ra">
-        <jms:reference-file line="69">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="70">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.overview.role.value.ra</source>
         <target>RA</target>
       </trans-unit>
       <trans-unit id="ac982ab35b7b5438a72cb6e243975c8ddd35e148" resname="ra.management.overview.role.value.raa">
-        <jms:reference-file line="70">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.overview.role.value.raa</source>
         <target>RAA</target>
       </trans-unit>
       <trans-unit id="53c4452d09c417bfb728d1e738b2ae2bbff3c883" resname="ra.management.overview.role.value.sraa">
-        <jms:reference-file line="71">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="72">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.management.overview.role.value.sraa</source>
         <target>SRAA</target>
       </trans-unit>
@@ -825,22 +830,22 @@
         <target>verander</target>
       </trans-unit>
       <trans-unit id="ff49fbf3684f01850a026abeff8b6f3cd6d89a98" resname="ra.prove_phone_possession.challenge_expired">
-        <jms:reference-file line="25">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.prove_phone_possession.challenge_expired</source>
         <target>Uw code is verlopen. Vraag een nieuwe code aan.</target>
       </trans-unit>
       <trans-unit id="f4e4a44fa84430b2d144a6dee71c69e914a963dd" resname="ra.prove_phone_possession.challenge_response_incorrect">
-        <jms:reference-file line="24">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="25">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.prove_phone_possession.challenge_response_incorrect</source>
         <target>Deze code is niet juist. Probeer het nog eens, of vraag een nieuwe code op.</target>
       </trans-unit>
       <trans-unit id="0d9cb3b18021e2899cf1031812da9a489b60093d" resname="ra.prove_phone_possession.too_many_attempts">
-        <jms:reference-file line="26">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.prove_phone_possession.too_many_attempts</source>
         <target>U heeft de limiet van tien pogingen bereikt; u kunt geen codes meer verifiëren. Neem contact op met uw helpdesk of probeer het later nog eens.</target>
       </trans-unit>
       <trans-unit id="06ada20a09df4484b41e75a58e813b54d4904f33" resname="ra.prove_yubikey_possession.different_yubikey_used">
-        <jms:reference-file line="20">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.prove_yubikey_possession.different_yubikey_used</source>
         <target>Tijdens het registratieproces heeft de gebruiker een andere Yubikey gebruikt.</target>
       </trans-unit>
@@ -1032,22 +1037,22 @@
         <target>Type</target>
       </trans-unit>
       <trans-unit id="5396da3d169284da408b7e41c919fc3cbb0a7789" resname="ra.second_factor.search.status.revoked">
-        <jms:reference-file line="36">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="37">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.status.revoked</source>
         <target>Verwijderd</target>
       </trans-unit>
       <trans-unit id="b95f6a983c4cb565e06b2b444afd9e53737e41d7" resname="ra.second_factor.search.status.unverified">
-        <jms:reference-file line="33">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="34">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.status.unverified</source>
         <target>Niet geverifieerd</target>
       </trans-unit>
       <trans-unit id="342a7ca495a8ab8baf8c65ca63c53558cb01688d" resname="ra.second_factor.search.status.verified">
-        <jms:reference-file line="34">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.status.verified</source>
         <target>Geverifieerd</target>
       </trans-unit>
       <trans-unit id="876f09e852960f57e319006c49585af1bbd55a84" resname="ra.second_factor.search.status.vetted">
-        <jms:reference-file line="35">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="36">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.status.vetted</source>
         <target>Geactiveerd</target>
       </trans-unit>
@@ -1062,22 +1067,22 @@
         <target>Beveiligingstokens</target>
       </trans-unit>
       <trans-unit id="e806f4c23b643c67a31167df8119efee18fae7a6" resname="ra.second_factor.search.type.sms">
-        <jms:reference-file line="29">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="30">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.type.sms</source>
         <target>SMS</target>
       </trans-unit>
       <trans-unit id="681292ebf2622b5e28a501e75394f550688e0ee4" resname="ra.second_factor.search.type.tiqr">
-        <jms:reference-file line="31">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="32">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.type.tiqr</source>
         <target>Tiqr</target>
       </trans-unit>
       <trans-unit id="7c92f246db43cf7cf51f891825e9ac95422ec7ef" resname="ra.second_factor.search.type.u2f">
-        <jms:reference-file line="32">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="33">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.type.u2f</source>
         <target>U2F</target>
       </trans-unit>
       <trans-unit id="85d8e5c7803600b08c39830c29a12bee3aa97146" resname="ra.second_factor.search.type.yubikey">
-        <jms:reference-file line="30">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.second_factor.search.type.yubikey</source>
         <target>Yubikey</target>
       </trans-unit>
@@ -1107,7 +1112,7 @@
         <target>Sessie Verlopen</target>
       </trans-unit>
       <trans-unit id="a718fae8b5a05ddfe4f55f3ed1a4bb8b365ea12c" resname="ra.sms_send_challenge.send_sms_challenge_failed">
-        <jms:reference-file line="23">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.sms_send_challenge.send_sms_challenge_failed</source>
         <target>Het versturen van de SMS-code is mislukt.</target>
       </trans-unit>
@@ -1117,27 +1122,28 @@
         <target>Je instituut is veranderd naar "%institution%"</target>
       </trans-unit>
       <trans-unit id="abe2e824031a2393db11918365a49cf65d3ec585" resname="ra.verify_identity.identity_verification_failed">
-        <jms:reference-file line="8">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="9">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.identity_verification_failed</source>
         <target>De verificatie van de identiteit is mislukt</target>
       </trans-unit>
       <trans-unit id="eff2ebc67229b22b80526799953593c40a2c6ef9" resname="ra.verify_identity.registration_code_expired">
-        <jms:reference-file line="9">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="228">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="10">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.registration_code_expired</source>
         <target>De activatie code is verlopen. Verwijder eerst de huidige token registratie (door RA of gebruiker). De gebruiker start vervolgens een nieuwe registratie via %self_service_url% en ontvangt een nieuwe activatiecode die weer 14 dagen geldig blijft.</target>
       </trans-unit>
       <trans-unit id="ba1980036b712688f6681fb8f86ac6925a1cba5a" resname="ra.verify_identity.second_factor_vetting_failed">
-        <jms:reference-file line="7">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="8">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.second_factor_vetting_failed</source>
         <target>Het beveiligingstoken kon om onbekende redenen niet gekeurd worden.</target>
       </trans-unit>
       <trans-unit id="7b8f4a813ad65c5f70c2f28e3459db2300aa11d8" resname="ra.verify_yubikey_command.otp.otp_invalid">
-        <jms:reference-file line="18">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_yubikey_command.otp.otp_invalid</source>
         <target>De Yubikey code is ongeldig. Probeer het nog eens</target>
       </trans-unit>
       <trans-unit id="669fe8c5f63adab894fc62f2bbf036f2fe9e8b6c" resname="ra.verify_yubikey_command.otp.verification_error">
-        <jms:reference-file line="19">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_yubikey_command.otp.verification_error</source>
         <target>De Yubikey-code kon om onbekende redenen niet geverifieerd worden.</target>
       </trans-unit>
@@ -1153,48 +1159,48 @@
       </trans-unit>
       <trans-unit id="32b7bc724e0d07eac8325753ae89605966b495c7" resname="ra.vetting.flash.cancelled">
         <jms:reference-file line="120">Controller/Vetting/SmsController.php</jms:reference-file>
-        <jms:reference-file line="144">RaBundle/Controller/VettingController.php</jms:reference-file>
-        <jms:reference-file line="174">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="154">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="184">RaBundle/Controller/VettingController.php</jms:reference-file>
         <source>ra.vetting.flash.cancelled</source>
         <target>De activatieprocedure is afgebroken.</target>
       </trans-unit>
       <trans-unit id="1dec0b54fa1739f15b995a5a8a3acb03adeff07d" resname="ra.vetting.gssf.initiate.biometric.button.initiate">
-        <jms:reference-file line="45">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="46">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.biometric.button.initiate</source>
         <target>Biometrie verifiëren</target>
       </trans-unit>
       <trans-unit id="94b9f4e4392a0b3cdf5cff65cf8951cb2ee4b3ba" resname="ra.vetting.gssf.initiate.biometric.error.gssf_id_mismatch">
-        <jms:reference-file line="46">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="47">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.biometric.error.gssf_id_mismatch</source>
         <target>Het biometrisch apparaat heeft een ID teruggegeven dat niet overeenkomt met het gevraagde ID, dat de registrant heeft geregistreerd in de Self-Service-applicatie.</target>
       </trans-unit>
       <trans-unit id="900abec75af2dfb739b1f7a9e73695385893b0d0" resname="ra.vetting.gssf.initiate.biometric.text.explanation">
-        <jms:reference-file line="44">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="45">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.biometric.text.explanation</source>
         <target>Klik de knop hieronder om de registrant biometrisch te verifiëren.</target>
       </trans-unit>
       <trans-unit id="ee546154768e6aa0c5075029912a2b01d7cd5ab6" resname="ra.vetting.gssf.initiate.biometric.title.page">
-        <jms:reference-file line="43">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="44">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.biometric.title.page</source>
         <target>Biometrie verifiëren</target>
       </trans-unit>
       <trans-unit id="485287b4d4e2f13a9df979601799e727821b9817" resname="ra.vetting.gssf.initiate.tiqr.button.initiate">
-        <jms:reference-file line="41">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="42">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.tiqr.button.initiate</source>
         <target>Verifiëren bij Tiqr</target>
       </trans-unit>
       <trans-unit id="e6ca047d4a5ae812276be6e8ece30cc7d6102af2" resname="ra.vetting.gssf.initiate.tiqr.error.gssf_id_mismatch">
-        <jms:reference-file line="42">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="43">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.tiqr.error.gssf_id_mismatch</source>
         <target>De Tiqr-server heeft een ID teruggegeven dat niet overeenkomt met het gevraagde ID, dat de registrant heeft geregistreerd in de Self-Service-applicatie.</target>
       </trans-unit>
       <trans-unit id="a5ec286b6d7f1ba6056eb720211d748ca9e8844c" resname="ra.vetting.gssf.initiate.tiqr.text.explanation">
-        <jms:reference-file line="40">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="41">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.tiqr.text.explanation</source>
         <target>Klik de knop hieronder om te verifiëren dat de registrant het Tiqr-account bezit dat hij of zij gebruikt heeft in de Self-Service-applicatie.</target>
       </trans-unit>
       <trans-unit id="cb3ffa7493a6cbda2c134ee5c2b80f193f822737" resname="ra.vetting.gssf.initiate.tiqr.title.page">
-        <jms:reference-file line="39">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="40">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.gssf.initiate.tiqr.title.page</source>
         <target>Tiqr verifiëren</target>
       </trans-unit>
@@ -1219,22 +1225,22 @@
         <target>Identiteit controleren</target>
       </trans-unit>
       <trans-unit id="f264bf655086664d56fe4803d21b31286b15d6ec" resname="ra.vetting.second_factor_type_disabled.text.explanation.sms">
-        <jms:reference-file line="12">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.second_factor_type_disabled.text.explanation.sms</source>
         <target>Het tokentype SMS is uitgeschakeld. Neem contact op met de helpdesk om dit probleem te verhelpen.</target>
       </trans-unit>
       <trans-unit id="ef613fe71984bbd610ab57eaa7c0e99bf780ac4b" resname="ra.vetting.second_factor_type_disabled.text.explanation.tiqr">
-        <jms:reference-file line="14">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="15">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.second_factor_type_disabled.text.explanation.tiqr</source>
         <target>Het tokentype Tiqr is uitgeschakeld. Neem contact op met de helpdesk om dit probleem te verhelpen.</target>
       </trans-unit>
       <trans-unit id="81f416a526dd1635fe0d3c1db52d1f4c2cb99b8a" resname="ra.vetting.second_factor_type_disabled.text.explanation.u2f">
-        <jms:reference-file line="15">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="16">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.second_factor_type_disabled.text.explanation.u2f</source>
         <target>Het tokentype U2F is uitgeschakeld. Neem contact op met de helpdesk om dit probleem te verhelpen.</target>
       </trans-unit>
       <trans-unit id="cf1e0f5a486105a8a24c5039a153454148398375" resname="ra.vetting.second_factor_type_disabled.text.explanation.yubikey">
-        <jms:reference-file line="13">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="14">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.second_factor_type_disabled.text.explanation.yubikey</source>
         <target>Het tokentype Yubikey is uitgeschakeld. Neem contact op met de helpdesk om dit probleem te verhelpen.</target>
       </trans-unit>
@@ -1294,12 +1300,12 @@
         <target>Home</target>
       </trans-unit>
       <trans-unit id="385d56fffaf0e844dcd7b164b18741f050ba28e7" resname="ra.vetting.u2f.alert.device_reported_an_error">
-        <jms:reference-file line="76">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="77">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.u2f.alert.device_reported_an_error</source>
         <target>Het U2F-apparaat heeft een foutmelding gerapporteerd. Probeer het opnieuw of neem contact op met de IT-helpdesk.</target>
       </trans-unit>
       <trans-unit id="467eb86ef7b096d0e14386714ef1b120c3f6b834" resname="ra.vetting.u2f.alert.error">
-        <jms:reference-file line="77">Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="78">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.vetting.u2f.alert.error</source>
         <target>De authenticate met het U2F-apparaat is mislukt. Probeer het opnieuw of neem contact op met de IT-helpdesk.</target>
       </trans-unit>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-11-08T14:27:42Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2016-11-25T14:35:48Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -31,11 +31,6 @@
         <jms:reference-file line="3">Resources/views/translations.twig</jms:reference-file>
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
-      </trans-unit>
-      <trans-unit id="2c51bcecf7826f003b2e051e4176c14b46372263" resname="ra.auditlog.event">
-        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
-        <source>ra.auditlog.event</source>
-        <target>Gebeurtenis</target>
       </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">
         <jms:reference-file line="62">Resources/views/translations.html.twig</jms:reference-file>
@@ -122,12 +117,17 @@
         <source>ra.auditlog.email</source>
         <target>E-mail</target>
       </trans-unit>
+      <trans-unit id="5f6db090607f031547304b8d4eaaf0b57c9a76a9" resname="ra.auditlog.event">
+        <jms:reference-file line="24">views/SecondFactor/auditLog.html.twig</jms:reference-file>
+        <source>ra.auditlog.event</source>
+        <target>Gebeurtenis</target>
+      </trans-unit>
       <trans-unit id="8a542621cac70df8e15d200c8bd2f2b650663849" resname="ra.auditlog.no_entries">
         <jms:reference-file line="44">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.no_entries</source>
         <target>Er zijn geen records in de audit log gevonden</target>
       </trans-unit>
-      <trans-unit id="2624da444b36c4d337a4287b9150b40fbcd68cb6" resname="ra.auditlog.second_factor_identifier">
+      <trans-unit id="5e0d6e050bc563d5e4b8f419651120cd8f250825" resname="ra.auditlog.second_factor_identifier">
         <jms:reference-file line="22">views/SecondFactor/auditLog.html.twig</jms:reference-file>
         <source>ra.auditlog.second_factor_identifier</source>
         <target>Token identifier</target>
@@ -1116,12 +1116,18 @@
         <source>ra.sraa.changed_institution</source>
         <target>Je instituut is veranderd naar "%institution%"</target>
       </trans-unit>
+      <trans-unit id="2c1d6651fe44a724bafa00301191bc7ffa19e27c" resname="ra.verify_identity.different_institution_error">
+        <jms:reference-file line="220">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <source>ra.verify_identity.different_institution_error</source>
+        <target>Registrant kan niet gevet worden: hij zit bij een ander instituut</target>
+      </trans-unit>
       <trans-unit id="abe2e824031a2393db11918365a49cf65d3ec585" resname="ra.verify_identity.identity_verification_failed">
         <jms:reference-file line="8">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.identity_verification_failed</source>
         <target>De verificatie van de identiteit is mislukt</target>
       </trans-unit>
       <trans-unit id="eff2ebc67229b22b80526799953593c40a2c6ef9" resname="ra.verify_identity.registration_code_expired">
+        <jms:reference-file line="227">RaBundle/Controller/VettingController.php</jms:reference-file>
         <jms:reference-file line="9">Resources/views/translations.html.twig</jms:reference-file>
         <source>ra.verify_identity.registration_code_expired</source>
         <target>De activatie code is verlopen. Verwijder eerst de huidige token registratie (door RA of gebruiker). De gebruiker start vervolgens een nieuwe registratie via %self_service_url% en ontvangt een nieuwe activatiecode die weer 14 dagen geldig blijft.</target>
@@ -1153,8 +1159,8 @@
       </trans-unit>
       <trans-unit id="32b7bc724e0d07eac8325753ae89605966b495c7" resname="ra.vetting.flash.cancelled">
         <jms:reference-file line="120">Controller/Vetting/SmsController.php</jms:reference-file>
-        <jms:reference-file line="144">RaBundle/Controller/VettingController.php</jms:reference-file>
-        <jms:reference-file line="174">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="145">RaBundle/Controller/VettingController.php</jms:reference-file>
+        <jms:reference-file line="175">RaBundle/Controller/VettingController.php</jms:reference-file>
         <source>ra.vetting.flash.cancelled</source>
         <target>De activatieprocedure is afgebroken.</target>
       </trans-unit>
@@ -1244,7 +1250,7 @@
         <target>Tokentype uitgeschakeld</target>
       </trans-unit>
       <trans-unit id="8e4a356a46fe95b04ae1cbb201b8d62e15670b2e" resname="ra.vetting.sms.challenge_body">
-        <jms:reference-file line="216">RaBundle/Service/VettingService.php</jms:reference-file>
+        <jms:reference-file line="217">RaBundle/Service/VettingService.php</jms:reference-file>
         <source>ra.vetting.sms.challenge_body</source>
         <target>Uw SMS-code: %challenge%</target>
       </trans-unit>

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -44,6 +44,9 @@ class VettingController extends Controller
      * @Template
      * @param Request $request
      * @return array|Response
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Form validation and error handling
+     * @SuppressWarnings(PHPMD.NPathComplexity) Form validation and error handling
      */
     public function startProcedureAction(Request $request)
     {
@@ -68,6 +71,15 @@ class VettingController extends Controller
         if ($secondFactor === null) {
             $form->addError(new FormError('ra.form.start_vetting_procedure.unknown_registration_code'));
             $logger->notice('Cannot start new vetting procedure, no second factor found');
+
+            return ['form' => $form->createView()];
+        }
+
+        if (!$this->isGranted('ROLE_SRAA') && $secondFactor->institution !== $this->getIdentity()->institution) {
+            $form->addError(new FormError('ra.form.start_vetting_procedure.different_institution_error'));
+            $logger->notice(
+                'Cannot start new vetting procedure, registrant belongs to a different institution than RA'
+            );
 
             return ['form' => $form->createView()];
         }

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -152,10 +152,6 @@ class VettingController extends Controller
      * @param Request $request
      * @param string $procedureId
      * @return array|Response
-     *
-     * The complexity should be reduced when refactoring cross-application error messaging
-     * @SuppressWarnings(PHPMD.NPathComplexity)
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function verifyIdentityAction(Request $request, $procedureId)
     {
@@ -219,18 +215,16 @@ class VettingController extends Controller
 
             $logger->error('RA attempted to vet second factor, but the command failed');
 
-            foreach ($vetting->getErrors() as $error) {
-                if (strpos($error, VettingService::REGISTRATION_CODE_EXPIRED_ERROR_FRAGMENT) !== false) {
-                    $registrationCodeExpiredError = $this->getTranslator()
-                        ->trans(
-                            'ra.verify_identity.registration_code_expired',
-                            [
-                                '%self_service_url%' => $this->getParameter('surfnet_stepup_ra.self_service_url'),
-                            ]
-                        );
+            if (in_array(VettingService::REGISTRATION_CODE_EXPIRED_ERROR, $vetting->getErrors())) {
+                $registrationCodeExpiredError = $this->getTranslator()
+                    ->trans(
+                        'ra.verify_identity.registration_code_expired',
+                        [
+                            '%self_service_url%' => $this->getParameter('surfnet_stepup_ra.self_service_url'),
+                        ]
+                    );
 
-                    return $showForm($registrationCodeExpiredError);
-                }
+                return $showForm($registrationCodeExpiredError);
             }
 
             return $showForm('ra.verify_identity.second_factor_vetting_failed');

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -45,8 +45,8 @@ class VettingController extends Controller
      * @param Request $request
      * @return array|Response
      *
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Form validation and error handling
-     * @SuppressWarnings(PHPMD.NPathComplexity) Form validation and error handling
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) https://www.pivotaltracker.com/story/show/135045063
+     * @SuppressWarnings(PHPMD.NPathComplexity)      https://www.pivotaltracker.com/story/show/135045063
      */
     public function startProcedureAction(Request $request)
     {

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -231,13 +231,6 @@ class VettingController extends Controller
 
                     return $showForm($registrationCodeExpiredError);
                 }
-
-                if (strpos($error, VettingService::DIFFERENT_INSTITUTION_ERROR_FRAGMENT) > -1) {
-                    $differentInstitutionError = $this->getTranslator()
-                        ->trans('ra.verify_identity.different_institution_error');
-
-                    return $showForm($differentInstitutionError);
-                }
             }
 
             return $showForm('ra.verify_identity.second_factor_vetting_failed');

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -231,6 +231,13 @@ class VettingController extends Controller
 
                     return $showForm($registrationCodeExpiredError);
                 }
+
+                if (strpos($error, VettingService::DIFFERENT_INSTITUTION_ERROR_FRAGMENT) > -1) {
+                    $differentInstitutionError = $this->getTranslator()
+                        ->trans('ra.verify_identity.different_institution_error');
+
+                    return $showForm($differentInstitutionError);
+                }
             }
 
             return $showForm('ra.verify_identity.second_factor_vetting_failed');

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig
@@ -2,6 +2,7 @@
 
 {# VettingController #}
 {{ 'ra.form.start_vetting_procedure.unknown_registration_code'|trans }}
+{{ 'ra.form.start_vetting_procedure.different_institution_error'|trans }}
 {{ 'ra.form.start_vetting_procedure.loa_insufficient'|trans }}
 {{ 'ra.form.start_vetting_procedure.enter_activation_code_here'|trans }}
 {{ 'ra.verify_identity.second_factor_vetting_failed'|trans }}

--- a/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
@@ -52,8 +52,6 @@ class VettingService
 {
     const REGISTRATION_CODE_EXPIRED_ERROR_FRAGMENT = 'the registration window is closed';
 
-    const DIFFERENT_INSTITUTION_ERROR_FRAGMENT = 'the RA belongs to a different institution';
-
     /**
      * @var \Surfnet\StepupBundle\Service\SmsSecondFactorService
      */

--- a/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
@@ -50,7 +50,8 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class VettingService
 {
-    const REGISTRATION_CODE_EXPIRED_ERROR_FRAGMENT = 'the registration window is closed';
+    const REGISTRATION_CODE_EXPIRED_ERROR =
+        'Surfnet\Stepup\Exception\DomainException: Cannot vet second factor, the registration window is closed.';
 
     /**
      * @var \Surfnet\StepupBundle\Service\SmsSecondFactorService

--- a/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
@@ -52,6 +52,8 @@ class VettingService
 {
     const REGISTRATION_CODE_EXPIRED_ERROR_FRAGMENT = 'the registration window is closed';
 
+    const DIFFERENT_INSTITUTION_ERROR_FRAGMENT = 'the RA belongs to a different institution';
+
     /**
      * @var \Surfnet\StepupBundle\Service\SmsSecondFactorService
      */

--- a/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
@@ -50,8 +50,7 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class VettingService
 {
-    const REGISTRATION_CODE_EXPIRED_ERROR =
-        'Surfnet\Stepup\Exception\DomainException: Cannot vet second factor, the registration window is closed.';
+    const REGISTRATION_CODE_EXPIRED_ERROR_FRAGMENT = 'the registration window is closed';
 
     /**
      * @var \Surfnet\StepupBundle\Service\SmsSecondFactorService


### PR DESCRIPTION
This PR mitigates the issue that RAs can vet registrants with a different institution than they have.

This relates to SURFnet/Stepup-Middleware#160.

![screen shot 2016-11-25 at 16 48 58](https://cloud.githubusercontent.com/assets/3816591/20630060/183dc952-b32f-11e6-9d02-ae125ae7e31d.png)

At first, I added this check to the final verification step. This was not necessary as we have enough information to stop earlier in the process. This explains the reverted commits. The changes to the domain shall remain, see: SURFnet/Stepup-Middleware#160.