### PR TITLE
Add CSV export to RA Management search results

### DIFF
--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -344,6 +344,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/StepupRa/RaBundle/Controller/SecondFactorController.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\<Surfnet\\\\StepupRa\\\\RaBundle\\\\Command\\\\SearchRaListingCommand\\>\\:\\:getClickedButton\\(\\)\\.$#',
+	'identifier' => 'method.notFound',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserProviderInterface\\:\\:findById\\(\\)\\.$#',
 	'identifier' => 'method.notFound',
 	'count' => 1,
@@ -714,12 +720,6 @@ $ignoreErrors[] = [
 	'identifier' => 'assign.propertyType',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/StepupRa/RaBundle/Service/RaCandidateService.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Left side of && is always true\\.$#',
-	'identifier' => 'booleanAnd.leftAlwaysTrue',
-	'count' => 2,
-	'path' => __DIR__ . '/../../src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$raInstitution of method Surfnet\\\\StepupMiddlewareClient\\\\Identity\\\\Dto\\\\RaListingSearchQuery\\:\\:setRaInstitution\\(\\) expects string, string\\|null given\\.$#',

--- a/src/Surfnet/StepupRa/RaBundle/Command/ExportRaListingCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/ExportRaListingCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Command;
+
+use DateTime;
+use Surfnet\StepupRa\RaBundle\Value\RoleAtInstitution;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class ExportRaListingCommand
+{
+    #[Assert\NotBlank(message: 'ra.search_ra_listing.actor_id.blank')]
+    #[Assert\Type('string', message: 'ra.search_ra_listing.actor_id.type')]
+    public $actorId;
+
+    /**
+     * @var string|null
+     */
+    public $name;
+
+    /**
+     * @var string|null
+     */
+    public $email;
+
+    /**
+     * @var string|null
+     */
+    public $institution;
+
+    /**
+     * @var RoleAtInstitution|null
+     */
+    public $roleAtInstitution;
+
+    /**
+     * Builds the command from a SearchRaListingCommand
+     */
+    public static function fromSearchCommand(SearchRaListingCommand $command): ExportRaListingCommand
+    {
+        $exportCommand = new self;
+
+        $exportCommand->actorId = $command->actorId;
+        $exportCommand->name = $command->name;
+        $exportCommand->email = $command->email;
+        $exportCommand->institution = $command->institution;
+        $exportCommand->roleAtInstitution = $command->roleAtInstitution;
+
+        return $exportCommand;
+    }
+
+    public function getFileName(): string
+    {
+        $date = new DateTime();
+        $date = $date->format('Y-m-d');
+
+        $role = $this->roleAtInstitution instanceof RoleAtInstitution && $this->roleAtInstitution->hasRole()
+            ? $this->roleAtInstitution->getRole()
+            : null;
+
+        return match ($role) {
+            'ra' => "ra_export_{$date}",
+            'raa' => "raa_export_{$date}",
+            default => "ra-raa-export_{$date}",
+        };
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Command/ExportRaListingCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/ExportRaListingCommand.php
@@ -24,6 +24,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 final class ExportRaListingCommand
 {
+    /**
+     * @var string
+     */
     #[Assert\NotBlank(message: 'ra.search_ra_listing.actor_id.blank')]
     #[Assert\Type('string', message: 'ra.search_ra_listing.actor_id.type')]
     public $actorId;

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -24,6 +24,7 @@ use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaCandidateInstitution;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListing;
 use Surfnet\StepupRa\RaBundle\Command\AccreditCandidateCommand;
 use Surfnet\StepupRa\RaBundle\Command\AmendRegistrationAuthorityInformationCommand;
+use Surfnet\StepupRa\RaBundle\Command\ExportRaListingCommand;
 use Surfnet\StepupRa\RaBundle\Command\RetractRegistrationAuthorityCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaCandidatesCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaListingCommand;
@@ -89,6 +90,11 @@ class RaManagementController extends AbstractController
         $form = $this->createForm(SearchRaListingType::class, $command, ['method' => 'get']);
         $form->handleRequest($request);
 
+        if ($form->isSubmitted() && $form->getClickedButton()?->getName() === 'export') {
+            $this->logger->notice('Forwarding to export RA(A) listing action');
+            return $this->forward('\Surfnet\StepupRa\RaBundle\Controller\RaManagementController::export', ['command' => $command]);
+        }
+
         $raList = $this->raListingService->search($command);
 
         $pagination = $this->paginator->paginate(
@@ -115,6 +121,16 @@ class RaManagementController extends AbstractController
                 'pagination' => $pagination,
             ],
         );
+    }
+
+    #[IsGranted('ROLE_RAA')]
+    public function export(SearchRaListingCommand $command): Response
+    {
+        $this->logger->notice('Starting export of searched RA(A) listing');
+
+        $exportCommand = ExportRaListingCommand::fromSearchCommand($command);
+
+        return $this->raListingService->export($exportCommand);
     }
 
     #[Route(

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/RoleAtInstitutionType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/RoleAtInstitutionType.php
@@ -52,6 +52,7 @@ class RoleAtInstitutionType extends AbstractType
             'choices' => RaRoleChoiceList::create(),
             'choice_value' => fn($choice) => $choice,
             'required' => $isRequired,
+            'placeholder' => $isRequired ? null : 'ra.form.role_at_institution.placeholder.role',
         ])->add('institution', ChoiceType::class, [
             'label' => 'ra.form.role_at_institution.label.institution',
             'choices' => $selectRaaOptions,

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaListingType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaListingType.php
@@ -50,10 +50,25 @@ class SearchRaListingType extends AbstractType
                 'choices' => $data->raInstitutionFilterOptions,
                 'label' => 'ra.form.ra_search_ra_listing.label.role',
                 'required' => false,
-            ])->add('search', SubmitType::class, [
+            ]);
+
+        $buttonGroup = $builder->create(
+            'button-group',
+            ButtonGroupType::class,
+            [
+                'mapped' => false,
+            ],
+        )
+            ->add('search', SubmitType::class, [
                 'label' => 'ra.form.ra_search_ra_listing.button.search',
                 'attr' => ['class' => 'btn btn-primary search-button'],
+            ])
+            ->add('export', SubmitType::class, [
+                'label' => 'ra.form.ra_search_ra_listing.button.export',
+                'attr' => ['class' => 'btn btn-secondary'],
             ]);
+
+        $builder->add($buttonGroup);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -215,11 +215,16 @@ services:
     Surfnet\StepupRa\RaBundle\Service\RaLocationService:
         alias: ra.service.ra_location
 
+    ra.service.ra_listing_exporter:
+        class: Surfnet\StepupRa\RaBundle\Service\RaListingExport
+        arguments:
+            - "@logger"
+
     ra.service.ra_listing:
         class: Surfnet\StepupRa\RaBundle\Service\RaListingService
         arguments:
             - "@surfnet_stepup_middleware_client.identity.service.ra_listing"
-            - "@logger"
+            - "@ra.service.ra_listing_exporter"
     Surfnet\StepupRa\RaBundle\Service\RaListingService:
         alias: ra.service.ra_listing
 

--- a/src/Surfnet/StepupRa/RaBundle/Service/RaListingExport.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaListingExport.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Service;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListing;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class RaListingExport
+{
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    /**
+     * @param RaListing[] $raListings
+     */
+    public function export(array $raListings, string $fileName): StreamedResponse
+    {
+        $this->logger->notice(sprintf('Exporting %d rows to "%s"', count($raListings), $fileName));
+
+        $columnNames = $this->getColumnNames();
+
+        return new StreamedResponse(
+            function () use ($raListings, $columnNames) {
+                $handle = fopen('php://output', 'r+');
+                fputcsv($handle, $columnNames);
+                foreach ($raListings as $raListing) {
+                    fputcsv($handle, [
+                        $raListing->commonName,
+                        $raListing->email,
+                        $raListing->institution,
+                        $raListing->role,
+                        $raListing->raInstitution,
+                        $raListing->location,
+                        $raListing->contactInformation,
+                    ]);
+                }
+                fflush($handle);
+                fclose($handle);
+            },
+            Response::HTTP_OK,
+            [
+                'Content-Type' => 'application/csv',
+                'Content-Disposition' => sprintf('attachment; filename="%s.csv"', $fileName),
+            ],
+        );
+    }
+
+    private function getColumnNames(): array
+    {
+        return [
+            'Common Name',
+            'Email',
+            'Institution',
+            'Role',
+            'RA Institution',
+            'Location',
+            'Contact Information',
+        ];
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Service/RaListingExport.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaListingExport.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Service;
 
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListing;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -41,6 +42,9 @@ class RaListingExport
         return new StreamedResponse(
             function () use ($raListings, $columnNames) {
                 $handle = fopen('php://output', 'r+');
+                if ($handle === false) {
+                    throw new RuntimeException('Unable to open php://output for writing the RA(A) listing export');
+                }
                 fputcsv($handle, $columnNames);
                 foreach ($raListings as $raListing) {
                     fputcsv($handle, [
@@ -64,6 +68,9 @@ class RaListingExport
         );
     }
 
+    /**
+     * @return string[]
+     */
     private function getColumnNames(): array
     {
         return [

--- a/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
@@ -22,12 +22,16 @@ use Surfnet\StepupMiddlewareClient\Identity\Dto\RaListingSearchQuery;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListing;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListingCollection;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaListingService as ApiRaListingService;
+use Surfnet\StepupRa\RaBundle\Command\ExportRaListingCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaListingCommand;
+use Surfnet\StepupRa\RaBundle\Value\RoleAtInstitution;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final readonly class RaListingService
 {
     public function __construct(
         private ApiRaListingService $apiRaListingService,
+        private RaListingExport $raListingExport,
     ) {
     }
 
@@ -37,35 +41,16 @@ final readonly class RaListingService
      */
     public function search(SearchRaListingCommand $command): RaListingCollection
     {
-        $query = new RaListingSearchQuery($command->actorId, $command->pageNumber);
-
-        if ($command->name) {
-            $query->setName($command->name);
-        }
-
-        if ($command->email) {
-            $query->setEmail($command->email);
-        }
-
-        if ($command->institution) {
-            $query->setInstitution($command->institution);
-        }
-
-        if ($command->roleAtInstitution && $command->roleAtInstitution->hasRole()) {
-            $query->setRole($command->roleAtInstitution->getRole());
-        }
-
-        if ($command->roleAtInstitution && $command->roleAtInstitution->hasInstitution()) {
-            $query->setRaInstitution($command->roleAtInstitution->getInstitution());
-        }
-
-        if ($command->orderBy) {
-            $query->setOrderBy($command->orderBy);
-        }
-
-        if ($command->orderDirection) {
-            $query->setOrderDirection($command->orderDirection);
-        }
+        $query = $this->buildQuery(
+            $command->actorId,
+            $command->pageNumber,
+            $command->name,
+            $command->email,
+            $command->institution,
+            $command->roleAtInstitution,
+            $command->orderBy,
+            $command->orderDirection,
+        );
 
         return $this->apiRaListingService->search($query);
     }
@@ -73,5 +58,81 @@ final readonly class RaListingService
     public function get(string $identityId, string $institution, string $actorId): ?RaListing
     {
         return $this->apiRaListingService->get($identityId, $institution, $actorId);
+    }
+
+    /**
+     * Pages through all RA listing results matching the given filters (bypassing UI pagination)
+     * and streams them as a CSV export.
+     */
+    public function export(ExportRaListingCommand $command): StreamedResponse
+    {
+        $raListings = [];
+        $pageNumber = 1;
+
+        do {
+            $query = $this->buildQuery(
+                $command->actorId,
+                $pageNumber,
+                $command->name,
+                $command->email,
+                $command->institution,
+                $command->roleAtInstitution,
+            );
+
+            $collection = $this->apiRaListingService->search($query);
+            $raListings = array_merge($raListings, $collection->getElements());
+
+            $lastPage = (int) ceil($collection->getTotalItems() / max($collection->getItemsPerPage(), 1));
+            $pageNumber++;
+        } while ($pageNumber <= $lastPage);
+
+        return $this->raListingExport->export($raListings, $command->getFileName());
+    }
+
+    /**
+     * @SuppressWarnings("PHPMD.CyclomaticComplexity") -- The command to query mapping exceeds the
+     * @SuppressWarnings("PHPMD.NPathComplexity") CyclomaticComplexity and NPathComplexity threshold.
+     */
+    private function buildQuery(
+        string $actorId,
+        int $pageNumber,
+        ?string $name,
+        ?string $email,
+        ?string $institution,
+        ?RoleAtInstitution $roleAtInstitution,
+        ?string $orderBy = null,
+        ?string $orderDirection = null,
+    ): RaListingSearchQuery {
+        $query = new RaListingSearchQuery($actorId, $pageNumber);
+
+        if ($name) {
+            $query->setName($name);
+        }
+
+        if ($email) {
+            $query->setEmail($email);
+        }
+
+        if ($institution) {
+            $query->setInstitution($institution);
+        }
+
+        if ($roleAtInstitution && $roleAtInstitution->hasRole()) {
+            $query->setRole($roleAtInstitution->getRole());
+        }
+
+        if ($roleAtInstitution && $roleAtInstitution->hasInstitution()) {
+            $query->setRaInstitution($roleAtInstitution->getInstitution());
+        }
+
+        if ($orderBy) {
+            $query->setOrderBy($orderBy);
+        }
+
+        if ($orderDirection) {
+            $query->setOrderDirection($orderDirection);
+        }
+
+        return $query;
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Command/ExportRaListingCommandTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Command/ExportRaListingCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Tests\Command;
+
+use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Surfnet\StepupRa\RaBundle\Command\ExportRaListingCommand;
+use Surfnet\StepupRa\RaBundle\Command\SearchRaListingCommand;
+use Surfnet\StepupRa\RaBundle\Value\RoleAtInstitution;
+
+class ExportRaListingCommandTest extends TestCase
+{
+    #[Test]
+    public function from_search_command_copies_the_relevant_filter_fields()
+    {
+        $roleAtInstitution = new RoleAtInstitution();
+        $roleAtInstitution->setRole('ra');
+
+        $searchCommand = new SearchRaListingCommand();
+        $searchCommand->actorId = 'actor-id';
+        $searchCommand->name = 'Jane Doe';
+        $searchCommand->email = 'jane@example.org';
+        $searchCommand->institution = 'institution-a';
+        $searchCommand->roleAtInstitution = $roleAtInstitution;
+        $searchCommand->pageNumber = 3;
+        $searchCommand->orderBy = 'name';
+        $searchCommand->orderDirection = 'desc';
+
+        $exportCommand = ExportRaListingCommand::fromSearchCommand($searchCommand);
+
+        $this->assertSame('actor-id', $exportCommand->actorId);
+        $this->assertSame('Jane Doe', $exportCommand->name);
+        $this->assertSame('jane@example.org', $exportCommand->email);
+        $this->assertSame('institution-a', $exportCommand->institution);
+        $this->assertSame($roleAtInstitution, $exportCommand->roleAtInstitution);
+    }
+
+    #[Test]
+    #[DataProvider('fileNameProvider')]
+    public function get_file_name_reflects_the_role_filter(?string $role, string $expectedPrefix)
+    {
+        $command = new ExportRaListingCommand();
+        $command->actorId = 'actor-id';
+
+        if ($role !== null) {
+            $roleAtInstitution = new RoleAtInstitution();
+            $roleAtInstitution->setRole($role);
+            $command->roleAtInstitution = $roleAtInstitution;
+        }
+
+        $date = (new DateTime())->format('Y-m-d');
+
+        $this->assertSame($expectedPrefix . '_' . $date, $command->getFileName());
+    }
+
+    public static function fileNameProvider(): array
+    {
+        return [
+            'ra role filter' => ['ra', 'ra_export'],
+            'raa role filter' => ['raa', 'raa_export'],
+            'no role filter' => [null, 'ra-raa-export'],
+        ];
+    }
+
+    #[Test]
+    public function get_file_name_treats_role_at_institution_without_a_role_as_unfiltered()
+    {
+        $command = new ExportRaListingCommand();
+        $command->actorId = 'actor-id';
+        $command->roleAtInstitution = new RoleAtInstitution();
+
+        $date = (new DateTime())->format('Y-m-d');
+
+        $this->assertSame('ra-raa-export_' . $date, $command->getFileName());
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Service/RaListingExportTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Service/RaListingExportTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Tests\Service;
+
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListing;
+use Surfnet\StepupRa\RaBundle\Service\RaListingExport;
+
+class RaListingExportTest extends TestCase
+{
+    #[Test]
+    public function it_streams_a_csv_with_a_header_row_and_a_row_per_listing()
+    {
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('notice');
+
+        $export = new RaListingExport($logger);
+
+        $raListing = new RaListing();
+        $raListing->identityId = 'identity-id';
+        $raListing->commonName = 'Jane Doe';
+        $raListing->email = 'jane@example.org';
+        $raListing->institution = 'institution-a';
+        $raListing->role = 'ra';
+        $raListing->raInstitution = 'institution-a';
+        $raListing->location = 'Room 101';
+        $raListing->contactInformation = '+31 6 12345678';
+
+        $response = $export->export([$raListing], 'ra_export_2026-07-24');
+
+        $this->assertSame('application/csv', $response->headers->get('Content-Type'));
+        $this->assertSame(
+            'attachment; filename="ra_export_2026-07-24.csv"',
+            $response->headers->get('Content-Disposition'),
+        );
+
+        ob_start();
+        $response->sendContent();
+        $csv = ob_get_clean();
+
+        $rows = array_map(
+            fn(string $line) => str_getcsv($line, escape: ''),
+            explode("\n", rtrim(str_replace("\r\n", "\n", $csv), "\n")),
+        );
+
+        $this->assertSame(
+            ['Common Name', 'Email', 'Institution', 'Role', 'RA Institution', 'Location', 'Contact Information'],
+            $rows[0],
+        );
+        $this->assertSame(
+            ['Jane Doe', 'jane@example.org', 'institution-a', 'ra', 'institution-a', 'Room 101', '+31 6 12345678'],
+            $rows[1],
+        );
+    }
+
+    #[Test]
+    public function it_streams_only_the_header_row_when_there_are_no_listings()
+    {
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('notice');
+
+        $export = new RaListingExport($logger);
+
+        $response = $export->export([], 'ra-raa-export_2026-07-24');
+
+        ob_start();
+        $response->sendContent();
+        $csv = ob_get_clean();
+
+        $rows = array_map(
+            fn(string $line) => str_getcsv($line, escape: ''),
+            explode("\n", rtrim(str_replace("\r\n", "\n", $csv), "\n")),
+        );
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(
+            ['Common Name', 'Email', 'Institution', 'Role', 'RA Institution', 'Location', 'Contact Information'],
+            $rows[0],
+        );
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Service/RaListingServiceTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Service/RaListingServiceTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Tests\Service;
+
+use DateTime;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Surfnet\StepupMiddlewareClient\Identity\Dto\RaListingSearchQuery;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListing;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListingCollection;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaListingService as ApiRaListingService;
+use Surfnet\StepupRa\RaBundle\Command\ExportRaListingCommand;
+use Surfnet\StepupRa\RaBundle\Service\RaListingExport;
+use Surfnet\StepupRa\RaBundle\Service\RaListingService;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class RaListingServiceTest extends TestCase
+{
+    #[Test]
+    public function export_pages_through_all_results_and_hands_the_full_set_to_the_exporter()
+    {
+        $firstPage = $this->collectionOf(['identity-1', 'identity-2'], totalItems: 3, page: 1, itemsPerPage: 2);
+        $secondPage = $this->collectionOf(['identity-3'], totalItems: 3, page: 2, itemsPerPage: 2);
+
+        $apiService = Mockery::mock(ApiRaListingService::class);
+        $apiService
+            ->shouldReceive('search')
+            ->once()
+            ->with(Mockery::on(fn (RaListingSearchQuery $query) => str_contains($query->toHttpQuery(), 'p=1')))
+            ->andReturn($firstPage);
+        $apiService
+            ->shouldReceive('search')
+            ->once()
+            ->with(Mockery::on(fn (RaListingSearchQuery $query) => str_contains($query->toHttpQuery(), 'p=2')))
+            ->andReturn($secondPage);
+
+        $expectedResponse = Mockery::mock(StreamedResponse::class);
+        $export = Mockery::mock(RaListingExport::class);
+        $export
+            ->shouldReceive('export')
+            ->once()
+            ->with(
+                Mockery::on(function (array $listings) {
+                    return array_map(fn (RaListing $listing) => $listing->identityId, $listings)
+                        === ['identity-1', 'identity-2', 'identity-3'];
+                }),
+                'ra-raa-export_' . (new DateTime())->format('Y-m-d'),
+            )
+            ->andReturn($expectedResponse);
+
+        $service = new RaListingService($apiService, $export);
+
+        $command = new ExportRaListingCommand();
+        $command->actorId = 'actor-id';
+
+        $this->assertSame($expectedResponse, $service->export($command));
+    }
+
+    #[Test]
+    public function export_only_queries_a_single_page_when_there_are_no_results()
+    {
+        $emptyPage = RaListingCollection::empty();
+
+        $apiService = Mockery::mock(ApiRaListingService::class);
+        $apiService
+            ->shouldReceive('search')
+            ->once()
+            ->andReturn($emptyPage);
+
+        $expectedResponse = Mockery::mock(StreamedResponse::class);
+        $export = Mockery::mock(RaListingExport::class);
+        $export
+            ->shouldReceive('export')
+            ->once()
+            ->with([], Mockery::type('string'))
+            ->andReturn($expectedResponse);
+
+        $service = new RaListingService($apiService, $export);
+
+        $command = new ExportRaListingCommand();
+        $command->actorId = 'actor-id';
+
+        $this->assertSame($expectedResponse, $service->export($command));
+    }
+
+    /**
+     * @param string[] $identityIds
+     */
+    private function collectionOf(
+        array $identityIds,
+        int $totalItems,
+        int $page,
+        int $itemsPerPage,
+    ): RaListingCollection {
+        $elements = array_map(function (string $identityId) {
+            $listing = new RaListing();
+            $listing->identityId = $identityId;
+            $listing->commonName = $identityId;
+            $listing->email = $identityId . '@example.org';
+            $listing->institution = 'institution-a';
+            $listing->role = 'ra';
+            $listing->raInstitution = 'institution-a';
+            $listing->location = '';
+            $listing->contactInformation = '';
+
+            return $listing;
+        }, $identityIds);
+
+        return new RaListingCollection($elements, $totalItems, $page, $itemsPerPage);
+    }
+}

--- a/translations/messages+intl-icu.en_GB.xliff
+++ b/translations/messages+intl-icu.en_GB.xliff
@@ -241,6 +241,10 @@
         <source>ra.form.ra_search_ra_candidates.label.name</source>
         <target>Name</target>
       </trans-unit>
+      <trans-unit id="k9J3xLp" resname="ra.form.ra_search_ra_listing.button.export">
+        <source>ra.form.ra_search_ra_listing.button.export</source>
+        <target>Export</target>
+      </trans-unit>
       <trans-unit id="gIS06rq" resname="ra.form.ra_search_ra_listing.button.search">
         <source>ra.form.ra_search_ra_listing.button.search</source>
         <target>Search</target>
@@ -372,6 +376,10 @@
       <trans-unit id="OI4DewE" resname="ra.form.role_at_institution.label.institution">
         <source>ra.form.role_at_institution.label.institution</source>
         <target>@</target>
+      </trans-unit>
+      <trans-unit id="p7VmQ2z" resname="ra.form.role_at_institution.placeholder.role">
+        <source>ra.form.role_at_institution.placeholder.role</source>
+        <target>RA/RAA</target>
       </trans-unit>
       <trans-unit id="SqK9YfO" resname="ra.form.select_institution.button.switch">
         <source>ra.form.select_institution.button.switch</source>

--- a/translations/messages+intl-icu.nl_NL.xliff
+++ b/translations/messages+intl-icu.nl_NL.xliff
@@ -241,6 +241,10 @@
         <source>ra.form.ra_search_ra_candidates.label.name</source>
         <target>Naam</target>
       </trans-unit>
+      <trans-unit id="k9J3xLp" resname="ra.form.ra_search_ra_listing.button.export">
+        <source>ra.form.ra_search_ra_listing.button.export</source>
+        <target>Exporteren</target>
+      </trans-unit>
       <trans-unit id="gIS06rq" resname="ra.form.ra_search_ra_listing.button.search">
         <source>ra.form.ra_search_ra_listing.button.search</source>
         <target>Zoeken</target>
@@ -372,6 +376,10 @@
       <trans-unit id="OI4DewE" resname="ra.form.role_at_institution.label.institution">
         <source>ra.form.role_at_institution.label.institution</source>
         <target>ra.form.role_at_institution.label.institution</target>
+      </trans-unit>
+      <trans-unit id="p7VmQ2z" resname="ra.form.role_at_institution.placeholder.role">
+        <source>ra.form.role_at_institution.placeholder.role</source>
+        <target>RA/RAA</target>
       </trans-unit>
       <trans-unit id="SqK9YfO" resname="ra.form.select_institution.button.switch">
         <source>ra.form.select_institution.button.switch</source>


### PR DESCRIPTION
## Summary
- Adds an Export button next to Search on the RA Management page, matching the existing Tokens (Second Factors) page pattern.
- `RaListingService::export()` pages through the existing paginated middleware search (no unpaginated export endpoint exists for RA listings) and streams the aggregated results as CSV via a new `RaListingExport` service.
- Export filename follows the role filter: `ra_export_YYYY-MM-DD`, `raa_export_YYYY-MM-DD`, or `ra-raa-export_YYYY-MM-DD` when unfiltered.
- Renames the blank Role filter option to a "RA/RAA" placeholder.
- `export()` keeps its own `ROLE_RAA` authorization check, independent of `manage()`.

## Test plan
- [x] `php -l` on all changed/new PHP files
- [x] XML validation of both translation xliff files
- [x] YAML validation of `services.yml`
- [x] Manually verified in a local docker-devconf environment (smoketest mode): logged in as RAA, submitted search with no/RA/RAA role filters, clicked Export each time, confirmed correct filenames and CSV row content/filtering
- [x] Confirmed a plain RA (no RAA) user cannot access the export button or action
- [ ] Unit tests for `ExportRaListingCommand::fromSearchCommand`, `RaListingService::export`, `RaListingExport::export` (not yet added)

Closes #498