### PR TITLE
Add translation for deprovisioned audit log action

### DIFF
--- a/translations/messages+intl-icu.en_GB.xliff
+++ b/translations/messages+intl-icu.en_GB.xliff
@@ -77,6 +77,10 @@
         <source>ra.auditlog.action.created</source>
         <target>Identity Created</target>
       </trans-unit>
+      <trans-unit id="hK6e.Tv" resname="ra.auditlog.action.deprovisioned">
+        <source>ra.auditlog.action.deprovisioned</source>
+        <target>Deprovisioned</target>
+      </trans-unit>
       <trans-unit id="jvc4R21" resname="ra.auditlog.action.email_changed">
         <source>ra.auditlog.action.email_changed</source>
         <target>E-mail changed</target>

--- a/translations/messages+intl-icu.nl_NL.xliff
+++ b/translations/messages+intl-icu.nl_NL.xliff
@@ -77,6 +77,10 @@
         <source>ra.auditlog.action.created</source>
         <target>Identiteit aangemaakt</target>
       </trans-unit>
+      <trans-unit id="hK6e.Tv" resname="ra.auditlog.action.deprovisioned">
+        <source>ra.auditlog.action.deprovisioned</source>
+        <target>Gedeprovisioneerd</target>
+      </trans-unit>
       <trans-unit id="jvc4R21" resname="ra.auditlog.action.email_changed">
         <source>ra.auditlog.action.email_changed</source>
         <target>E-mail gewijzigd</target>


### PR DESCRIPTION
## Summary
- Adds the `ra.auditlog.action.deprovisioned` translation (EN + NL) so the audit log can display a "Deprovisioned" event
- No template/PHP change needed: `audit_log.html.twig` already renders any `action` key generically, alongside the existing `recordedOn` timestamp for every row

## Out of scope
- Emitting the `deprovisioned` audit log event, and retroactively backfilling it for already-deprovisioned identities, is handled on the Stepup-Middleware side

Closes #423

## Test plan
- [ ] `COMPOSER_MEMORY_LIMIT=1G composer check-ci` passes
- [ ] Once Stepup-Middleware emits `action: "deprovisioned"` audit log entries, confirm the RA UI renders "Deprovisioned" with its timestamp