### PR TITLE
Fix institution mismatch after saving vetting-type-hint

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingTypeHintController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingTypeHintController.php
@@ -111,10 +111,12 @@ class VettingTypeHintController extends AbstractController
 
             if ($success) {
                 $this->addFlash('success', 'ra.vetting_type_hint.success');
-            } else {
-                $this->logger->debug('Vetting type hint saving failed, adding error to form');
-                $this->addFlash('error', 'ra.vetting_type_hint.error');
+
+                return $this->redirectToRoute('vetting_type_hint', ['institution' => $command->institution]);
             }
+
+            $this->logger->debug('Vetting type hint saving failed, adding error to form');
+            $this->addFlash('error', 'ra.vetting_type_hint.error');
         }
 
         return $this->render(


### PR DESCRIPTION
## Summary
- After saving activation help text (vetting-type-hint) for an institution other than the RAA's home institution, the "Select institution" dropdown and page subtitle snapped back to the home institution while the displayed text stayed on the institution just edited.
- Redirect to the same route with the saved institution on success (POST/Redirect/GET), so the dropdown and subtitle stay in sync with the saved hints.
- On save failure, the form still re-renders in place so submitted input isn't lost.

Fixes #409

## Test plan
- [ ] As an RAA/SRAA with access to 2+ institutions, edit vetting-type-hint text for a non-home institution and save; confirm the dropdown and displayed text both show the edited institution afterwards.
- [ ] Confirm a failed save keeps the submitted hint text on the form instead of clearing it.
- [ ] `COMPOSER_MEMORY_LIMIT=1G composer check-ci` passes.